### PR TITLE
Improvements to logging, string extensions plus other minor improvements and fixes

### DIFF
--- a/Folder.DotSettings
+++ b/Folder.DotSettings
@@ -1,0 +1,8 @@
+﻿<wpf:ResourceDictionary xml:space="preserve" xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml" xmlns:s="clr-namespace:System;assembly=mscorlib" xmlns:ss="urn:shemas-jetbrains-com:settings-storage-xaml" xmlns:wpf="http://schemas.microsoft.com/winfx/2006/xaml/presentation">
+	<s:Boolean x:Key="/Default/CodeStyle/Naming/CSharpNaming/ApplyAutoDetectedRules/@EntryValue">False</s:Boolean>
+	<s:String x:Key="/Default/Environment/InjectedLayers/FileInjectedLayer/=57D87C6603F3E94DAB56499B3F65BD89/AbsolutePath/@EntryValue">C:\Users\Tim\OSS-Projects\TA.Utilities\TA.Utils.Specifications\TA.Utils.Specifications.csproj.DotSettings</s:String>
+	<s:String x:Key="/Default/Environment/InjectedLayers/FileInjectedLayer/=57D87C6603F3E94DAB56499B3F65BD89/RelativePath/@EntryValue">..\TA.Utils.Specifications\TA.Utils.Specifications.csproj.DotSettings</s:String>
+	<s:Boolean x:Key="/Default/Environment/InjectedLayers/FileInjectedLayer/=57D87C6603F3E94DAB56499B3F65BD89/@KeyIndexDefined">True</s:Boolean>
+	<s:Boolean x:Key="/Default/Environment/InjectedLayers/InjectedLayerCustomization/=File57D87C6603F3E94DAB56499B3F65BD89/@KeyIndexDefined">True</s:Boolean>
+	<s:Boolean x:Key="/Default/Environment/InjectedLayers/InjectedLayerCustomization/=File57D87C6603F3E94DAB56499B3F65BD89/IsOn/@EntryValue">False</s:Boolean>
+	<s:Double x:Key="/Default/Environment/InjectedLayers/InjectedLayerCustomization/=File57D87C6603F3E94DAB56499B3F65BD89/RelativePriority/@EntryValue">1</s:Double></wpf:ResourceDictionary>

--- a/Push-Packages.ps1
+++ b/Push-Packages.ps1
@@ -24,9 +24,10 @@ else {
 
 foreach ($package in $releasePackages) {
     if ($package.Name -like "*.snupkg") {
-        NuGet.exe push -Source $symbolFeed $package $setApiKey
+        #Symbols are supposed to be pushed alongside their related packacge, so no need for a separate push.
+        #NuGet.exe push -Source $symbolFeed $package $setApiKey
     }
     else {
-        NuGet.exe push -Source $packageFeed $package $setApiKey
+        NuGet.exe push -SkipDuplicate -Source $packageFeed $package $setApiKey
     }
 }

--- a/ReadMe.md
+++ b/ReadMe.md
@@ -1,16 +1,19 @@
-# Tigra Astronomy Commonly Used Helpers and Utilities #
+# Timtek Commonly Used Helpers and Utilities
 
 This library represents a collection of classes factored out of our production projects, that we found were being used over and over again.
-Rather than re-using the code at source level, it is now collected together in this package as a general purpose reusable library and made freely available for you to use.
+Rather than re-using the code at source level, it is now collected together in this package as a general purpose reusable library and made freely available for you to use at no cost and with no obligation. The only stipulation is that you can't sue the author or Timtek Systems Limited
+if anything bad happens as a result of you using the code. It's up to you to determine suitability for your purpose.
+
+## Software Re-use at the Object Code level
 
 This was always the promise of _Object Oriented Design_, but it was not until the advent of [NuGet][nuget] and its widespread adoption that this became a practical reality.
 It is easy to overlook the impact of [NuGet][nuget], as it seems so obvious and natural once you've used it.
 
-> Dependency management is the key challenge in software at every scale  
-> **Donald Knuth**, _The Art of Computer Programming_
+> "Dependency management is the key challenge in software at every scale." 
+> Possibly attributed to **Donald Knuth**, _The Art of Computer Programming_
 
 NuGet has essentially solved a large chunk of the dependency management problem.
-At Tigra Astronomy, we use NuGet it as a key component in our software design strategy.
+At Timtek Systems, we use NuGet as a key component in our software design strategy.
 We publish our open source code on a [public MyGet feed][myget].
 We push both prerelease and release versions to [MyGet][myget].
 When we make an official release, we promote that package from [MyGet][myget] to [NuGet][nuget].
@@ -26,7 +29,7 @@ We have no time for "copyleft" licenses which we find irksome.
 
 So here it is, for you to use however you like, no strings attached.
 
-I tend to use "we" and "our" when talking about the company, but Tigra Astronomy is a one-man operation run by me, Tim Long.
+I tend to use "we" and "our" when talking about the company, but Timtek Systems Limited is a one-man operation run by me, Tim Long.
 I hope you find the software useful, and if you feel that my efforts are worth supporting, then it would make my day if you would [buying me some coffee][coffee].
 I also wouldn't mind you giving us a mention, if you feel you are able to, as it helps the company grow. Donations and mentions really make a difference, so please think about it and do what you can.
 
@@ -36,7 +39,7 @@ If you are a company and need some work done, then consider hiring me as a freel
 
 ### Versioning ###
 
-Tigra Astronomy has settled on a versioning strategy based on [Semantic Versioning 2.0.0][semver].
+Timtek has settled on a versioning strategy based on [Semantic Versioning 2.0.0][semver].
 
 We give all of our software a semantic version, which we display to the user in the About box and write out to log files on startup.
 We use [GitVersion][gitversion] to [automatically assign a version number to every build][yt-gitversion] (even in [Arduino projects][yt-gitversion-arduino]).
@@ -45,7 +48,7 @@ So we can never forget to "bump the version" and we can never forget to set it.
 Total automation.
 If you examine one of our log files, you may well find something like this:
 
-``` lang=log
+```log
 21:16:59.2909|INFO |Server          |Git Commit ID: "229c1acc4a7bda494f78a8c7cc811c2a4d8e9132"
 21:16:59.3069|INFO |Server          |Git Short ID: "229c1ac"
 21:16:59.3069|INFO |Server          |Commit Date: "2020-07-11"
@@ -57,6 +60,8 @@ If you examine one of our log files, you may well find something like this:
 
 There's no mistaking where that build came from.
 
+[GitVersion][gitversion] also injects a static class into the assembly containing all the versioning information it computed based on your Git commit history.
+This information can be a little tricky to get at, because it doesn't exist at compile time so you can't easily reference it. You have to use Reflection to get at it.
 Our `GitVersion` class contains static properties for getting your semantic version metadata at runtime. We use it to write the log entries as shown above.
 
 ### Readability and Intention-revealing Code ###
@@ -71,11 +76,16 @@ Did you mean there wans't an error but you can't give an answer?
 Did you mean the answer was empty?
 Or did someone just forget to initialize the variable?
 
+I'm not a fan of Microsoft's solution to the Null Reference problem.
+I think their _Nullable Reference Types_ [sic] are clumsy and make the code look ugly.
+They couldn't even get the name right - reference types were *always* nullable!
+
 The ambiguity around "error" vs. "no value" is why we created `Maybe<T>`.
 
 `Maybe<T>` is a type that either has a value, or doesn't, but it is never null.
 The idea is that by using a `Maybe<T>` you clearly communicate your intentions to the caller.
-By returning `Maybe<T>` you nail down the ambiguity: "there might not be a value and you have to check".
+By returning `Maybe<T>` you nail down the ambiguity:
+"there might not be a value and you have to check".
 
 Strictly, a `Maybe<T>` is an `IEnumerable<T>` which is either empty (no value) or has exactly one element.
 Because it is `IEnumerable` you can use certain LINQ operators:
@@ -83,12 +93,11 @@ Because it is `IEnumerable` you can use certain LINQ operators:
 - `maybe.Any()` will be true if there is a value.
 - `maybe.Single()` gets you the value.
 - `maybe.SingleOrDefault()` gets you the value or `null`.
-- extension method `maybe.None()` is `true` if there's no value.
 
 Creating a maybe can be done by:
 
-- `object.AsMaybe();` - convert a reference type.
-- `Maybe<int>.From(7);` - works with value types.
+- `object.AsMaybe();` - wrap a non-null object.
+- `Maybe<int>.From(7);` - works with value types, and also safe for null references.
 - `Maybe<T>.Empty` - a maybe without a value.
 
 `Maybe<T>` has a `ToString()` method so you can write it to a stream or use in a string interpolation, and you will get the serialized value or "`{no value}`".
@@ -102,16 +111,21 @@ You may find that your bug count tends to diminish.
 
 An `Octet` is an immutable type that represents 8 bits, or a byte.
 In most cases, it can be directly used in place of a `byte` as there are implicit conversions to and from a `byte`.
-There are also explicit conversions to and from `int` and `uint`.
-The latter are explicit because there is potentially data loss, so use with care.
+There are also explicit conversions to and from `int`.
+The latter is explicit because there is potentially data loss, so use with care.
 
-In an `Octet`, each bit position is directly addressable.
+Note that conversion from `uint` has been deprecated because `uint` is not CLS Compliant, which can cause issues with other languages.
+
+In an `Octet`, each bit position is directly addressable as an array element.
 You can access `octet[0]` through `octet[7]`.
 
-You can set a bit with `octet.WithBitSetTo(n, state)`.
-Remember `Octet` is immutable so this gives you a new `Octet` and leaves the original unchanged.
+You can set a bit with `octet.WithBitSet(n)`.
+You can clear a bit with `octet.WithBitClear(n)`.
+
+Remember `Octet` is _immutable_ so this gives you a new `Octet` and leaves the original unchanged.
 
 You can perform logical bitwise operations using the `&` anf `|` operators.
+You can test octets for equality and compare them using `==`, `!=`, `>`, `<`, etc.
 
 ### Diagnostics ###
 
@@ -132,18 +146,38 @@ You can always get the equivalent human-readable display text for an enumerated 
 This will return the display text if it has been set, or the name of the enum value otherwise.
 Set the display text by dropping a `[DisplayEquivalent("text")]` attribute on each field of the enum.
 
+```csharp
+    [Subject(typeof(DisplayEquivalentAttribute))]
+    internal class when_displaying_an_enum_with_equivalent_text
+        {
+        It should_have_equivalent_text_when_the_attribute_is_present = () =>
+            TestCases.CaseWithEquivalentText.DisplayEquivalent().ShouldEqual("Equivalent Text");
+        It should_use_the_field_name_when_no_attribute_is_present = () =>
+            TestCases.CaseWithoutEquivalentText.DisplayEquivalent()
+                .ShouldEqual(nameof(TestCases.CaseWithoutEquivalentText));
+        }
+
+    internal enum TestCases
+        {
+        [DisplayEquivalent("Equivalent Text")] CaseWithEquivalentText,
+        CaseWithoutEquivalentText
+        }
+```
+
 ### Asynchrony and Threading ###
 
 #### ConfigureAwait ####
 
 There is an extension method in .NET used to configure awaitable tasks, called `ConfigureAwait(bool)`.
-THe method affects how the task awaiter schedules its continuation.
-With `ConfigureAwait(true)` the tasks continues on the current synchronization context.
+The method affects how the task awaiter schedules its continuation.
+With `ConfigureAwait(true)` the task continues on the current synchronization context.
 That usually means on the same thread, and is particularly relevant when the awaiter is a user interface thread.
-Conversely, `ConfigureAwait(false)` means that continuation can happen on any thread, and usually that will be a thread pool worker thread.
-The implications are quite profound. Consider the following method:
+Conversely, `ConfigureAwait(false)` means that continuation can happen on any thread, 
+and typically that will be a thread pool worker thread.
+The implications are quite profound, especially for apartment-threaded GUI applications such as WinForms or WPF. 
+Consider the following method:
 
-``` lang=cs
+```csharp
 public async Task SomeMethod()
     {
 	Console.WriteLine("Starting on thread {0}", Thread.CurrentThread.ManagedThreadId);
@@ -161,11 +195,12 @@ But it is not at all ovious how `ConfigureAwait()` should be used.
 What if you don't specifiy?
 Is the await configured or unconfigured?
 Does `ConfigureAwait(false)` mean you don't want to configure it, or that you want to configure it not to do something?
-It's just horrible, you can't read the code and instantly understand what it does, and that violates the _Principle of Least Astonishment_.
+It's just horrible.
+You can't read the code and instantly understand what it does, and that violates the _Principle of Least Astonishment_.
 
 So we made some extension methods that essentially do the same thing, but make more sense. Our aync method now becomes:
 
-``` lang=cs
+```csharp
 public async Task SomeMethod()
     {
 	Console.WriteLine("Starting on thread {0}", Thread.CurrentThread.ManagedThreadId);
@@ -181,7 +216,7 @@ and we get
 
 Alternatively:
 
-``` lang=cs
+```csharp
 public async Task SomeMethod()
     {
 	Console.WriteLine("Starting on thread {0}", Thread.CurrentThread.ManagedThreadId);
@@ -194,7 +229,7 @@ The await captures the current `SynchronizationContext` and uses it to schedule 
 What happens next depends on the application model and how it implements `SynchronizationContext`.
 For a user interface application, the UI generally runs in a Single Threaded Apartment (STA thread).
 In this model, asynchronous operations are posted to the message queue of the STA thread.
-The continuation will then happen on the UI thread once teh thread is idel and the message pump runs.
+The continuation will then happen on the UI thread once the thread is idle and the message pump runs.
 In a free-threaded application model such as a console application, the continuation will likely
 still happen on a different thread.
 
@@ -206,9 +241,10 @@ Therefore, best practice for library writers is to always use `ContinueOnAnyThre
 #### Cancel Culture ####
 
 One final extension method is `Task.WithCancellation(token)`.
-This takes a task that is not cancellable and adds cancellation to it.
-Note that this doesn't stop the task from running and it may still run to completion,
-but it means you don't have to wait for it.
+This takes a task that is not cancellable and wraps it in a cancellable task.
+Awaiters can then wait on the cancellable wrapper and will get to run if the wrapper is cancelled.
+Note that this doesn't stop the original task from running and it may still run to completion,
+but its result will be discarded as there should be nothing awaiting the result.
 
 #### Logging ####
 
@@ -228,14 +264,14 @@ whether the logger is null every time it is used.
 
 The interface supports semantic logging. You can use a simple format string like so:
 
-``` lang=cs
+```csharp
 log.Info().Message("Sending data {0}", data).Write();
 log.Error().Message("Exception {0} occurred with error code {1}", ex.Message, errorCode).Write();
 ```
 
 But this leaves useful information on the table. Extra rich information can be included like so:
 
-``` lang=cs
+```csharp
 log.Info().Message("Sending data {data}", data).Write();
 log.Error()
     .Message("Exception {exception} occurred with error code {error}")
@@ -275,7 +311,7 @@ For example:
 
 In most cases, the way in which log data is ultimately rendered is controlled by the application, often using a configuration file.
 As a library developer, you must accept that you have little to no control over this.
-Just concentrate in including appropriate and useful information and don't think about formatting or storage.
+Just concentrate on including appropriate and useful information and don't think about formatting or storage.
 
 [mit]: https://tigra.mit-license.org "Tigra MIT License"
 [semver]: https://semver.org/ "the rules of semantic versioning"

--- a/TA.Utils.Benchmarks/Program.cs
+++ b/TA.Utils.Benchmarks/Program.cs
@@ -1,0 +1,4 @@
+﻿using BenchmarkDotNet.Running;
+using TA.Utils.Benchmarks;
+
+BenchmarkRunner.Run<StringCleanBenchmark>();

--- a/TA.Utils.Benchmarks/StringCleanBenchmark.cs
+++ b/TA.Utils.Benchmarks/StringCleanBenchmark.cs
@@ -1,0 +1,55 @@
+﻿// This file is part of the TA.Utils project
+// Copyright © 2016-2023 Timtek Systems Limited, all rights reserved.
+// File: StringCleanBenchmark.cs  Last modified: 2023-08-14@02:34 by Tim Long
+
+using System.Text;
+using BenchmarkDotNet.Attributes;
+
+namespace TA.Utils.Benchmarks;
+
+public class StringCleanBenchmark
+    {
+    [Params("aeiou", ".,", "Lorem ipsum dolor sit amet")]
+    public string clean;
+    public string source = @"
+Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nullam felis eros, mattis eget libero vel, congue convallis felis. Nam vel finibus sapien, a iaculis nunc. Sed iaculis interdum feugiat. Sed ut mollis augue. Pellentesque urna ante, suscipit vel vestibulum quis, maximus non tortor. Cras ipsum neque, molestie id justo in, lobortis varius mauris. Etiam mollis pulvinar ligula, ut porta lorem eleifend vel. Integer metus mi, elementum ac aliquam placerat, feugiat ac ex. Quisque cursus sapien sed augue elementum, vel tristique lectus aliquam. Ut nunc elit, tristique at odio vitae, euismod gravida elit. Aenean tellus ligula, eleifend nec nisl sed, laoreet dapibus lectus.
+
+Interdum et malesuada fames ac ante ipsum primis in faucibus. Vivamus sit amet diam suscipit, placerat nisi vel, consectetur tellus. Sed pharetra magna eget nibh sollicitudin vehicula. Curabitur vel libero bibendum, lobortis est ut, pretium eros. Quisque ac condimentum massa. Suspendisse sit amet interdum metus, id hendrerit lorem. Nam id urna sagittis, rhoncus nisi sit amet, sodales neque. Nulla sit amet rutrum nibh. Nulla vel pharetra ipsum, ac gravida odio. Aliquam erat volutpat. In ut faucibus sapien. Aliquam accumsan consectetur ligula gravida feugiat. Nam dictum volutpat quam eget ullamcorper. Nam sollicitudin mauris quis lorem dictum, quis faucibus neque posuere. Aliquam erat volutpat.
+
+In sit amet quam molestie, scelerisque nisi vel, semper nisl. Nam posuere quam odio, ut congue nulla venenatis vel. Proin eu lacus et justo luctus fringilla. In hac habitasse platea dictumst. Donec ante nisl, molestie sit amet justo nec, dapibus iaculis mi. Quisque congue, leo et elementum blandit, mauris nulla cursus enim, et bibendum quam metus eget turpis. Nam fringilla arcu magna, at lacinia quam ornare nec. Nam hendrerit varius egestas. Nam magna tellus, ultrices in nisl placerat, placerat ultrices eros. Cras tincidunt, quam nec tempor vehicula, sem eros fermentum ipsum, vitae laoreet augue felis in ante.
+
+Morbi a lorem ultrices, tincidunt magna at, viverra nulla. Proin at lorem sit amet elit lacinia ullamcorper at id neque. Etiam vel mauris eget nisi egestas efficitur. Etiam lectus orci, vestibulum non dui ac, placerat molestie mi. Praesent laoreet quam sit amet augue sagittis sagittis. Maecenas sed porta lorem, at ornare ligula. Phasellus blandit ex id vulputate condimentum. Vestibulum et justo diam. Maecenas molestie a massa mattis ultrices. Quisque non velit nec turpis lobortis vulputate. Duis vitae elementum ipsum, a dignissim nisi.
+
+Ut tincidunt tincidunt nibh at porttitor. In hac habitasse platea dictumst. Morbi nec lobortis nunc, porttitor tincidunt felis. Praesent accumsan, neque eu bibendum egestas, mauris odio congue massa, eu rutrum ipsum leo sit amet purus. Donec finibus porta tristique. Aliquam molestie arcu ante, quis mattis velit bibendum sit amet. Suspendisse viverra sodales pellentesque. Nulla lorem ligula, vestibulum gravida neque vel, consectetur rutrum lorem. Aliquam malesuada et nibh id feugiat. Nam eget aliquam purus. Pellentesque habitant morbi tristique senectus et netus et malesuada fames ac turpis egestas. Aliquam at porttitor mauris. Sed non dictum sem.
+";
+
+    [Benchmark]
+    public string CleanWithHashMap()
+        {
+        if (string.IsNullOrEmpty(source))
+            return string.Empty;
+        if (string.IsNullOrEmpty(clean))
+            return source;
+        // HashSet.Contains is O(1) whereas string.Contains is O(n)
+        var cleanSet = new HashSet<char>(clean);
+        var cleanString = new StringBuilder(source.Length);
+        foreach (var ch in source)
+            if (!cleanSet.Contains(ch))
+                cleanString.Append(ch);
+        return cleanString.ToString();
+        }
+
+    [Benchmark]
+    public string CleanWithContains()
+        {
+        if (string.IsNullOrEmpty(source))
+            return string.Empty;
+        if (string.IsNullOrEmpty(clean))
+            return source;
+        var cleanString = new StringBuilder(source.Length);
+        foreach (var ch in source)
+            if (!clean.Contains(ch))
+                cleanString.Append(ch);
+        return cleanString.ToString();
+        }
+    }

--- a/TA.Utils.Benchmarks/TA.Utils.Benchmarks.csproj
+++ b/TA.Utils.Benchmarks/TA.Utils.Benchmarks.csproj
@@ -1,0 +1,14 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net6.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="BenchmarkDotNet" Version="0.13.7" />
+  </ItemGroup>
+
+</Project>

--- a/TA.Utils.Core/AssemblyAttributes.cs
+++ b/TA.Utils.Core/AssemblyAttributes.cs
@@ -1,0 +1,7 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Runtime.CompilerServices;
+using System.Text;
+
+// Make internals visible to unit test assemblies
+[assembly:InternalsVisibleTo("TA.Utils.Specifications")]

--- a/TA.Utils.Core/AssemblyAttributes.cs
+++ b/TA.Utils.Core/AssemblyAttributes.cs
@@ -1,7 +1,7 @@
 ﻿using System;
-using System.Collections.Generic;
 using System.Runtime.CompilerServices;
-using System.Text;
+
+[assembly: CLSCompliant(true)]
 
 // Make internals visible to unit test assemblies
-[assembly:InternalsVisibleTo("TA.Utils.Specifications")]
+[assembly: InternalsVisibleTo("TA.Utils.Specifications")]

--- a/TA.Utils.Core/Diagnostics/DegenerateLoggerService.cs
+++ b/TA.Utils.Core/Diagnostics/DegenerateLoggerService.cs
@@ -42,5 +42,8 @@ namespace TA.Utils.Core.Diagnostics
 
         /// <inheritdoc />
         public ILog WithAmbientProperty(string name, object value) => this;
+
+        /// <inheritdoc />
+        public ILog WithName(string logSourceName) => this;
     }
 }

--- a/TA.Utils.Core/Diagnostics/DegenerateLoggerService.cs
+++ b/TA.Utils.Core/Diagnostics/DegenerateLoggerService.cs
@@ -18,7 +18,7 @@ namespace TA.Utils.Core.Diagnostics
     /// </summary>
     public sealed class DegenerateLoggerService : ILog
     {
-        private static IFluentLogBuilder builder = new DegenerateLogBuilder();
+        private static readonly IFluentLogBuilder builder = new DegenerateLogBuilder();
         /// <inheritdoc />
         public IFluentLogBuilder Trace(string callerFilePath = null) => builder;
 

--- a/TA.Utils.Core/Diagnostics/IFluentLogBuilder.cs
+++ b/TA.Utils.Core/Diagnostics/IFluentLogBuilder.cs
@@ -11,84 +11,85 @@
 // File: IFluentLogBuilder.cs  Last modified: 2020-07-14@07:01 by Tim Long
 
 using System;
-using System.Collections;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Runtime.CompilerServices;
+using JetBrains.Annotations;
 
 namespace TA.Utils.Core.Diagnostics
     {
     /// <summary>
-    /// Fluent Log Builder
+    ///     Fluent Log Builder
     /// </summary>
     public interface IFluentLogBuilder
         {
         /// <summary>
-        /// Add an exception to the log entry.
+        ///     Add an exception to the log entry.
         /// </summary>
         IFluentLogBuilder Exception(Exception exception);
 
         /// <summary>
-        /// Set the log (source) name. By default, this is the name of the source file.
+        ///     Set the log (source) name. By default, this is usually the name of the class or source file.
         /// </summary>
         IFluentLogBuilder LoggerName(string loggerName);
 
         /// <summary>
-        /// Sets the message template for the log entry.
-        /// The message may be a simple plain text string,
-        /// it may contain numbered substitution tokens like string.Format,
-        /// or it may contain named substitution tokens enclosed in {braces}
+        ///     Sets the message template for the log entry.
+        ///     The message may be a simple plain text string,
+        ///     it may contain numbered substitution tokens like string.Format,
+        ///     or it may contain named substitution tokens enclosed in {braces}
         /// </summary>
-        IFluentLogBuilder Message(string message);
+        IFluentLogBuilder Message([StructuredMessageTemplate] string message);
 
         /// <summary>
-        /// Sets the message template and property values for the log entry.
-        /// The format string may use numbered positional placeholders like string.Format,
-        /// or it may contain named substitution tokens enclosed in {braces}.
+        ///     Sets the message template and property values for the log entry.
+        ///     The format string may use numbered positional placeholders like string.Format,
+        ///     or it may contain named substitution tokens enclosed in {braces}.
         /// </summary>
-        IFluentLogBuilder Message(string format, params object[] args);
+        IFluentLogBuilder Message([StructuredMessageTemplate] string format, params object[] args);
 
         /// <summary>
-        /// Sets the message template and property values for the log entry.
-        /// The format provider will be used when rendering the property values.
+        ///     Sets the message template and property values for the log entry.
+        ///     The format provider will be used when rendering the property values.
         /// </summary>
-        IFluentLogBuilder Message(IFormatProvider provider, string format, params object[] args);
+        IFluentLogBuilder Message(IFormatProvider provider, [StructuredMessageTemplate] string format,
+            params object[] args);
 
         /// <summary>
-        /// Adds a named property and value pair to the log entry.
+        ///     Adds a named property and value pair to the log entry.
         /// </summary>
         IFluentLogBuilder Property(string name, object value);
 
         /// <summary>
-        /// Adds a collection of property/value pairs to the log entry.
+        ///     Adds a collection of property/value pairs to the log entry.
         /// </summary>
-        IFluentLogBuilder Properties(IDictionary<string,object> properties);
+        IFluentLogBuilder Properties(IDictionary<string, object> properties);
 
         /// <summary>
-        /// Sets the time stamp of the log entry.
-        /// If not set, the log entry will be timed at the moment Write() was called.
+        ///     Sets the time stamp of the log entry.
+        ///     If not set, the log entry will be timed at the moment Write() was called.
         /// </summary>
         IFluentLogBuilder TimeStamp(DateTime timeStamp);
 
         /// <summary>
-        /// Adds a stack trace to the log entry.
+        ///     Adds a stack trace to the log entry.
         /// </summary>
         IFluentLogBuilder StackTrace(StackTrace stackTrace, int userStackFrame);
 
         /// <summary>
-        /// Writes the log entry.
+        ///     Writes the log entry.
         /// </summary>
         void Write([CallerMemberName] string callerMemberName = null, [CallerFilePath] string callerFilePath = null,
             [CallerLineNumber] int callerLineNumber = default);
 
         /// <summary>
-        /// Writes the log entry if the supplied predicate is true.
+        ///     Writes the log entry if the supplied predicate is true.
         /// </summary>
         void WriteIf(Func<bool> condition, [CallerMemberName] string callerMemberName = null,
             [CallerFilePath] string callerFilePath = null, [CallerLineNumber] int callerLineNumber = default);
 
         /// <summary>
-        /// Writes the log entry if the boolean condition is true.
+        ///     Writes the log entry if the boolean condition is true.
         /// </summary>
         void WriteIf(bool condition, [CallerMemberName] string callerMemberName = null,
             [CallerFilePath] string callerFilePath = null, [CallerLineNumber] int callerLineNumber = default);

--- a/TA.Utils.Core/Diagnostics/ILog.cs
+++ b/TA.Utils.Core/Diagnostics/ILog.cs
@@ -1,79 +1,76 @@
-﻿// This file is part of the TA.Ascom.ReactiveCommunications project
-//
-// Copyright © 2015-2020 Tigra Astronomy, all rights reserved.
-//
-// Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated
-// documentation files (the "Software"), to deal in the Software without restriction, including without limitation
-// the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to
-// permit persons to whom the Software is furnished to do so. The Software comes with no warranty of any kind.
-// You make use of the Software entirely at your own risk and assume all liability arising from your use thereof.
-//
-// File: ILog.cs  Last modified: 2020-07-14@06:59 by Tim Long
-
-using System.Runtime.CompilerServices;
+﻿using System.Runtime.CompilerServices;
 
 namespace TA.Utils.Core.Diagnostics
-{
+    {
     /// <summary>
-    /// Logging service interface
+    ///     Logging service interface
     /// </summary>
     public interface ILog
-    {
+        {
         /// <summary>
-        /// Creates a log builder for a log entry with Trace severity.
+        ///     Creates a log builder for a log entry with Trace severity.
         /// </summary>
         /// <param name="callerFilePath">The caller file path.</param>
         /// <returns>IFluentLogBuilder.</returns>
         IFluentLogBuilder Trace([CallerFilePath] string callerFilePath = null);
 
         /// <summary>
-        /// Creates a log builder for a log entry with Debug severity.
+        ///     Creates a log builder for a log entry with Debug severity.
         /// </summary>
         /// <param name="callerFilePath">The caller file path.</param>
         /// <returns>IFluentLogBuilder.</returns>
         IFluentLogBuilder Debug([CallerFilePath] string callerFilePath = null);
 
         /// <summary>
-        /// Creates a log builder for a log entry with Information severity.
+        ///     Creates a log builder for a log entry with Information severity.
         /// </summary>
         /// <param name="callerFilePath">The caller file path.</param>
         /// <returns>IFluentLogBuilder.</returns>
         IFluentLogBuilder Info([CallerFilePath] string callerFilePath = null);
 
         /// <summary>
-        /// Creates a log builder for a log entry with Warning severity.
+        ///     Creates a log builder for a log entry with Warning severity.
         /// </summary>
         /// <param name="callerFilePath">The caller file path.</param>
         /// <returns>IFluentLogBuilder.</returns>
         IFluentLogBuilder Warn([CallerFilePath] string callerFilePath = null);
 
         /// <summary>
-        /// Creates a log builder for a log entry with Error severity.
+        ///     Creates a log builder for a log entry with Error severity.
         /// </summary>
         /// <param name="callerFilePath">The caller file path.</param>
         /// <returns>IFluentLogBuilder.</returns>
         IFluentLogBuilder Error([CallerFilePath] string callerFilePath = null);
 
         /// <summary>
-        /// Creates a log builder for a log entry with Fatal severity.
-        /// Writing a Fatal log entry also terminates the process.
+        ///     Creates a log builder for a log entry with Fatal severity.
+        ///     Writing a Fatal log entry also terminates the process.
         /// </summary>
         /// <param name="callerFilePath">The caller file path.</param>
         /// <returns>IFluentLogBuilder.</returns>
         IFluentLogBuilder Fatal([CallerFilePath] string callerFilePath = null);
 
         /// <summary>
-        /// Instructs the logging service to shut down.
-        /// This should flush any buffered log entries and close any open files or streams.
-        /// It is best practice to call <c>Shutdown</c> before exiting from the program.
+        ///     Instructs the logging service to shut down.
+        ///     This should flush any buffered log entries and close any open files or streams.
+        ///     It is best practice to call <c>Shutdown</c> before exiting from the program.
         /// </summary>
         void Shutdown();
 
         /// <summary>
-        /// Sets an "ambient property" that should be included in all log events.
-        /// Once added, the property persists for the lifetim of the instance.
-        /// Useful for loggers that support semantic logging.
+        ///     Sets an "ambient property" that should be included in all log events.
+        ///     Once added, the property persists for the lifetim of the instance.
+        ///     Useful for loggers that support semantic logging.
         /// </summary>
         ILog WithAmbientProperty(string name, object value);
+
+        /// <summary>
+        /// Sets the name of the logger, which can be used by a logging back-end for filtering and routing
+        /// of log entries. If unset, then the value is implementation dependent and may default to the name
+        /// of the class or source file where the ILog instance is created or injected, or some other value.
+        /// </summary>
+        /// <param name="logSourceName"></param>
+        /// <returns></returns>
+        ILog WithName(string logSourceName);
+        }
     }
-}

--- a/TA.Utils.Core/EnumExtensions.cs
+++ b/TA.Utils.Core/EnumExtensions.cs
@@ -21,15 +21,14 @@ namespace TA.Utils.Core
         /// <seealso cref="DisplayEquivalentAttribute" />
         public static string DisplayEquivalent(this Enum en)
             {
-            string enumValueName = en.ToString();
+            var enumValueName = en.ToString();
             var type = en.GetType();
             var fields = type.GetTypeInfo().DeclaredFields;
             var fieldInfo = fields.Single(p => p.Name == enumValueName);
-            var attribute =
-                (DisplayEquivalentAttribute) fieldInfo?.GetCustomAttribute(typeof(DisplayEquivalentAttribute));
-            if (fieldInfo == null || attribute == null)
+            var attribute = (DisplayEquivalentAttribute) fieldInfo.GetCustomAttribute(typeof(DisplayEquivalentAttribute));
+            if (attribute == null)
                 return enumValueName;
-            string displayEquivalent = attribute.Value;
+            var displayEquivalent = attribute.Value;
             return string.IsNullOrWhiteSpace(displayEquivalent) ? enumValueName : displayEquivalent;
             }
         }

--- a/TA.Utils.Core/GitVersion.cs
+++ b/TA.Utils.Core/GitVersion.cs
@@ -93,7 +93,7 @@ namespace TA.Utils.Core
         /// <returns>Type.</returns>
         private static Type ReflectInjectedGitVersionType()
         {
-            var assembly = Assembly.GetEntryAssembly();
+            var assembly = Assembly.GetEntryAssembly()??Assembly.GetExecutingAssembly();
             var type = assembly.GetTypes().SingleOrDefault(t => t.Name == "GitVersionInformation");
             return type;
         }

--- a/TA.Utils.Core/GitVersion.cs
+++ b/TA.Utils.Core/GitVersion.cs
@@ -16,59 +16,68 @@ namespace TA.Utils.Core
     public static class GitVersion
     {
         /// <summary>The type injected by GitVersion during the build process, containing version information.</summary>
-        private static readonly Type InjectedVersion = ReflectInjectedGitVersionType();
+        private static Type injectedVersion = ReflectInjectedGitVersionType();
 
         /// <summary>Gets the git informational version.</summary>
         /// <value>The git informational version.</value>
         /// <seealso cref="SemanticVersion" />
-        public static string GitInformationalVersion => InjectedVersion.GitVersionField("InformationalVersion");
+        public static string GitInformationalVersion =>
+            injectedVersion?.GitVersionField("InformationalVersion") ?? GitFullSemVer;
 
         /// <summary>Gets the git commit SHA.</summary>
         /// <value>The git commit SHA.</value>
-        public static string GitCommitSha => InjectedVersion.GitVersionField("Sha");
+        public static string GitCommitSha => injectedVersion?.GitVersionField("Sha") ?? string.Empty;
 
         /// <summary>Gets the git commit short SHA.</summary>
         /// <value>The git commit short SHA.</value>
-        public static string GitCommitShortSha => InjectedVersion.GitVersionField("ShortSha");
+        public static string GitCommitShortSha => injectedVersion?.GitVersionField("ShortSha") ?? string.Empty;
 
         /// <summary>Gets the git commit date.</summary>
         /// <value>The git commit date.</value>
-        public static string GitCommitDate => InjectedVersion.GitVersionField("CommitDate");
+        public static string GitCommitDate => injectedVersion?.GitVersionField("CommitDate") ?? string.Empty;
 
         /// <summary>Gets the git semantic version string.</summary>
         /// <value>The git semantic version string.</value>
         /// <seealso cref="SemanticVersion" />
-        public static string GitSemVer => InjectedVersion.GitVersionField("SemVer");
+        public static string GitSemVer => injectedVersion?.GitVersionField("SemVer") ?? "0.0.0";
 
         /// <summary>Gets the git full semantic version string.</summary>
         /// <value>The git full semantic version string.</value>
         /// <seealso cref="SemanticVersion" />
-        public static string GitFullSemVer => InjectedVersion.GitVersionField("FullSemVer");
+        public static string GitFullSemVer => injectedVersion?.GitVersionField("FullSemVer") ?? "0.0.0-unversioned";
 
         /// <summary>Gets the git build metadata.</summary>
         /// <value>The git build metadata string.</value>
         /// <seealso cref="SemanticVersion" />
-        public static string GitBuildMetadata => InjectedVersion.GitVersionField("FullBuildMetaData");
+        public static string GitBuildMetadata => injectedVersion?.GitVersionField("FullBuildMetaData") ?? string.Empty;
 
         /// <summary>Gets the git major version.</summary>
         /// <value>The git major version, as a string.</value>
         /// <seealso cref="SemanticVersion" />
-        public static string GitMajorVersion => InjectedVersion.GitVersionField("Major");
+        public static string GitMajorVersion => injectedVersion?.GitVersionField("Major") ?? "0";
 
         /// <summary>Gets the git minor version.</summary>
         /// <value>The git minor version, as a string.</value>
         /// <seealso cref="SemanticVersion" />
-        public static string GitMinorVersion => InjectedVersion.GitVersionField("Minor");
+        public static string GitMinorVersion => injectedVersion?.GitVersionField("Minor") ?? "0";
 
         /// <summary>Gets the git patch version.</summary>
         /// <value>The git patch version, as a string.</value>
         /// <seealso cref="SemanticVersion" />
-        public static string GitPatchVersion => InjectedVersion.GitVersionField("Patch");
+        public static string GitPatchVersion => injectedVersion?.GitVersionField("Patch") ?? "0";
 
         /// <summary>Gets the name of the git branch from which the assembly was built.</summary>
         /// <value>The git branch name, as a string.</value>
         /// <seealso cref="SemanticVersion" />
-        public static string GitBranchName => InjectedVersion.GitVersionField("BranchName");
+        public static string GitBranchName => injectedVersion?.GitVersionField("BranchName") ?? string.Empty;
+
+        /// <summary>
+        ///     A method intended to be used for unit testing to set the injected version type to null. [#2]
+        /// </summary>
+        internal static void UnitTestNullInjectedVersionType()
+        {
+            injectedVersion = null;
+        }
 
         /// <summary>Uses reflection to fetch the value of a member field of the injected version information.</summary>
         /// <param name="gitVersionInformationType">Type of the git version information.</param>

--- a/TA.Utils.Core/Maybe.cs
+++ b/TA.Utils.Core/Maybe.cs
@@ -2,10 +2,14 @@
 // Copyright © 2016-2020 Tigra Astronomy, all rights reserved.
 // File: Maybe.cs  Last modified: 2020-07-13@02:11 by Tim Long
 
+using System;
 using System.Collections;
 using System.Collections.Generic;
+using System.ComponentModel;
+using System.Diagnostics;
 using System.Diagnostics.Contracts;
 using System.Linq;
+using JetBrains.Annotations;
 
 namespace TA.Utils.Core
     {
@@ -21,6 +25,7 @@ namespace TA.Utils.Core
     ///     versus 'error'.  The value of a Maybe cannot be <c>null</c>, because <c>null</c> really means
     ///     'no value' and that is better expressed by using <see cref="P:TA.Utils.Core.Maybe{T}.Empty" />.
     /// </remarks>
+    [ImmutableObject(true)]
     public sealed class Maybe<T> : IEnumerable<T>
         {
         private static readonly Maybe<T> EmptyInstance = new Maybe<T>();
@@ -30,14 +35,15 @@ namespace TA.Utils.Core
         /// <summary>Initializes a new instance of the <see cref="Maybe{T}" /> with no value.</summary>
         private Maybe()
             {
-            values = new T[0];
+            values = Array.Empty<T>();
             }
 
         /// <summary>Initializes a new instance of the <see cref="Maybe{T}" /> with a value.</summary>
         /// <param name="value">The value.</param>
-        private Maybe(T value)
+        private Maybe([NotNull] T value)
             {
-            values = new[] {value};
+            Debug.Assert(value != null);
+            values = new[] { value };
             }
 
         /// <summary>Gets an instance that does not contain a value.</summary>
@@ -53,7 +59,12 @@ namespace TA.Utils.Core
 
         /// <summary>Gets a value indicating whether this <see cref="Maybe{T}" /> is empty (has no value).</summary>
         /// <value><c>true</c> if none; otherwise, <c>false</c>.</value>
+        [Obsolete("Use IsEmpty instead.")]
         public bool None => ReferenceEquals(this, Empty) || !values.Any();
+
+        /// <summary>Gets a value indicating whether this <see cref="Maybe{T}" /> is empty (has no value).</summary>
+        /// <value><c>true</c> if there is no value; otherwise, <c>false</c>.</value>
+        public bool IsEmpty => ReferenceEquals(this, Empty) || !values.Any();
 
         /// <summary>Returns an enumerator that iterates through the collection.</summary>
         /// <returns>
@@ -90,13 +101,11 @@ namespace TA.Utils.Core
 
         /// <summary>Returns a <see cref="System.String" /> that represents this instance.</summary>
         /// <returns>A <see cref="System.String" /> that represents this instance.</returns>
-        [Pure]
+        [System.Diagnostics.Contracts.Pure]
         public override string ToString()
             {
             Contract.Ensures(Contract.Result<string>() != null);
-            if (Equals(Empty))
-                return "{no value}";
-            return this.Single().ToString();
+            return IsEmpty ? "{no value}" : this.Single().ToString();
             }
         }
 

--- a/TA.Utils.Core/Octet.cs
+++ b/TA.Utils.Core/Octet.cs
@@ -72,6 +72,7 @@ namespace TA.Utils.Core
         /// <param name="other">An object to compare with this object.</param>
         public bool Equals(Octet other)
             {
+            if (other is null) return false; // equality to a null object is false by definition
             for (var i = 0; i < bits.Length; i++)
                 if (bits[i] != other[i])
                     return false;
@@ -176,7 +177,7 @@ namespace TA.Utils.Core
         ///     Returns a new octet with the specified bit number set to the specified value. Other bits are
         ///     duplicated.
         /// </summary>
-        /// <param name="bit">The bit number to be modified.</param>
+        /// <param name="bitNumber">The bit number to be modified.</param>
         /// <param name="value">The value of the specified bit number.</param>
         /// <returns>A new octet instance with the specified bit number set to the specified value.</returns>
         public Octet WithBitSetTo(int bitNumber, bool value)
@@ -269,6 +270,8 @@ namespace TA.Utils.Core
         /// <returns><c>true</c> if the octets are equal; otherwise <c>false</c>.</returns>
         public static bool operator ==(Octet left, Octet right)
             {
+            if (left is null) return false;
+            if (right is null) return false;
             return left.Equals(right);
             }
 
@@ -278,6 +281,8 @@ namespace TA.Utils.Core
         /// <returns><c>true</c> if the octets are not equal; otherwise <c>false</c>.</returns>
         public static bool operator !=(Octet left, Octet right)
             {
+            if (left is null) return true; // Cannot be equal if either instance is null
+            if (right is null) return true;
             return !left.Equals(right);
             }
 

--- a/TA.Utils.Core/Octet.cs
+++ b/TA.Utils.Core/Octet.cs
@@ -72,7 +72,7 @@ namespace TA.Utils.Core
         /// <param name="other">An object to compare with this object.</param>
         public bool Equals(Octet other)
             {
-            for (int i = 0; i < bits.Length; i++)
+            for (var i = 0; i < bits.Length; i++)
                 if (bits[i] != other[i])
                     return false;
             return true;
@@ -97,9 +97,9 @@ namespace TA.Utils.Core
         public static Octet FromInt(int source)
             {
             var bits = new bool[8];
-            for (int i = 0; i < 8; i++)
+            for (var i = 0; i < 8; i++)
                 {
-                int bit = source & 0x01;
+                var bit = source & 0x01;
                 bits[i] = bit != 0;
                 source >>= 1;
                 }
@@ -110,9 +110,10 @@ namespace TA.Utils.Core
         /// <summary>Factory method: create an Octet from an unsigned integer.</summary>
         /// <param name="source">The source.</param>
         /// <returns>Octet.</returns>
+        [CLSCompliant(false)]
         public static Octet FromUnsignedInt(uint source)
             {
-            return FromInt((int) source);
+            return FromInt((int)source);
             }
 
         /// <summary>
@@ -122,6 +123,8 @@ namespace TA.Utils.Core
         /// <param name="bit">The bit number to be modified.</param>
         /// <param name="value">The value of the specified bit number.</param>
         /// <returns>A new octet instance with the specified bit number set to the specified value.</returns>
+        [CLSCompliant(false)]
+        [Obsolete("Use WithBitSet() or WithBitClear() instead")]
         public Octet WithBitSetTo(ushort bit, bool value)
             {
             Contract.Requires(bit < 8);
@@ -132,16 +135,53 @@ namespace TA.Utils.Core
             }
 
         /// <summary>
+        ///     Returns a new Octet instance with the specified bit set to 1. Other bits are duplicated from the current instance.
+        /// </summary>
+        /// <param name="bitNumber">
+        ///     The bit position to be set, where 0 is the least significant bit and 7 is the most significant
+        ///     bit.
+        /// </param>
+        /// <returns>A new Octet instance with the specified bit set to 1.</returns>
+        /// <exception cref="System.ArgumentOutOfRangeException">Thrown when bitNumber is less than 0 or greater than 7.</exception>
+        public Octet WithBitSet(int bitNumber)
+            {
+            Contract.Requires(bitNumber >= 0 && bitNumber < 8);
+            if (bitNumber < 0 || bitNumber > 7)
+                throw new ArgumentOutOfRangeException(nameof(bitNumber), bitNumber,
+                    $"{bitNumber} is not a valid bit number. Must be [0..7]");
+            var newBits = new bool[8];
+            bits.CopyTo(newBits, 0);
+            newBits[bitNumber] = true;
+            return new Octet(newBits);
+            }
+
+        /// <summary>
+        ///     Returns a new Octet instance with the specified bit number cleared (set to false). Other bits are unchanged.
+        /// </summary>
+        /// <param name="bitNumber">The bit number to be cleared. Must be between 0 and 7 inclusive.</param>
+        /// <returns>A new Octet instance with the specified bit number cleared.</returns>
+        public Octet WithBitClear(int bitNumber)
+            {
+            Contract.Requires(bitNumber >= 0 && bitNumber < 8);
+            if (bitNumber < 0 || bitNumber > 7)
+                throw new ArgumentOutOfRangeException(nameof(bitNumber), bitNumber,
+                    $"{bitNumber} is not a valid bit number. Must be [0..7]");
+            var newBits = new bool[8];
+            bits.CopyTo(newBits, 0);
+            newBits[bitNumber] = false;
+            return new Octet(newBits);
+            }
+
+        /// <summary>
         ///     Returns a new octet with the specified bit number set to the specified value. Other bits are
         ///     duplicated.
         /// </summary>
         /// <param name="bit">The bit number to be modified.</param>
         /// <param name="value">The value of the specified bit number.</param>
         /// <returns>A new octet instance with the specified bit number set to the specified value.</returns>
-        public Octet WithBitSetTo(int bit, bool value)
+        public Octet WithBitSetTo(int bitNumber, bool value)
             {
-            Contract.Requires(bit >= 0 && bit < 8);
-            return WithBitSetTo((ushort) bit, value);
+            return value ? WithBitSet(bitNumber) : WithBitClear(bitNumber);
             }
 
         /// <summary>Returns a <see cref="T:System.String" /> that represents the octet instance.</summary>
@@ -149,7 +189,7 @@ namespace TA.Utils.Core
         public override string ToString()
             {
             var builder = new StringBuilder();
-            for (int i = 7; i >= 0; i--)
+            for (var i = 7; i >= 0; i--)
                 {
                 builder.Append(bits[i] ? '1' : '0');
                 builder.Append(' ');
@@ -186,11 +226,11 @@ namespace TA.Utils.Core
         /// <returns>The result of the conversion.</returns>
         public static implicit operator byte(Octet octet)
             {
-            int sum = 0;
-            for (int i = 0; i < 8; i++)
+            var sum = 0;
+            for (var i = 0; i < 8; i++)
                 if (octet[i])
                     sum += 1 << i;
-            return (byte) sum;
+            return (byte)sum;
             }
 
         /// <summary>Performs an implicit conversion from <see cref="byte" /> to <see cref="Octet" />.</summary>
@@ -210,7 +250,7 @@ namespace TA.Utils.Core
         public override bool Equals(object other)
             {
             if (ReferenceEquals(null, other)) return false;
-            return other is Octet && Equals((Octet) other);
+            return other is Octet && Equals((Octet)other);
             }
 
         /// <summary>Returns a hash code for this instance.</summary>
@@ -247,8 +287,8 @@ namespace TA.Utils.Core
         /// <returns>A new octet containing the result of the bitwise logical AND operation.</returns>
         public static Octet operator &(Octet left, Octet right)
             {
-            var result = (bool[]) left.bits.Clone();
-            for (int i = 0; i < 8; i++) result[i] &= right[i];
+            var result = (bool[])left.bits.Clone();
+            for (var i = 0; i < 8; i++) result[i] &= right[i];
             return new Octet(result);
             }
 
@@ -258,8 +298,8 @@ namespace TA.Utils.Core
         /// <returns>A new octet containing the result of the bitwise logical OR operation.</returns>
         public static Octet operator |(Octet left, Octet right)
             {
-            var result = (bool[]) left.bits.Clone();
-            for (int i = 0; i < 8; i++) result[i] |= right[i];
+            var result = (bool[])left.bits.Clone();
+            for (var i = 0; i < 8; i++) result[i] |= right[i];
             return new Octet(result);
             }
         }

--- a/TA.Utils.Core/SemanticVersion.cs
+++ b/TA.Utils.Core/SemanticVersion.cs
@@ -403,11 +403,11 @@ namespace TA.Utils.Core
 
         private static int CompareBuildVersions(Maybe<string> leftVersion, Maybe<string> rightVersion)
             {
-            if (leftVersion.None && rightVersion.None)
+            if (leftVersion.IsEmpty && rightVersion.IsEmpty)
                 return 0; // equal if both absent
-            if (leftVersion.Any() && rightVersion.None)
+            if (leftVersion.Any() && rightVersion.IsEmpty)
                 return 1;
-            if (leftVersion.None && rightVersion.Any())
+            if (leftVersion.IsEmpty && rightVersion.Any())
                 return -1;
             int result = CompareSegmentBySegment(leftVersion.Single(), rightVersion.Single());
             return result;
@@ -417,7 +417,6 @@ namespace TA.Utils.Core
             {
             Contract.Requires(!string.IsNullOrEmpty(left));
             Contract.Requires(!string.IsNullOrEmpty(right));
-            int result;
             var dotDelimiter = new[] {'.'};
             var leftSegments = left.Split(dotDelimiter, StringSplitOptions.RemoveEmptyEntries);
             var rightSegments = right.Split(dotDelimiter, StringSplitOptions.RemoveEmptyEntries);
@@ -431,7 +430,7 @@ namespace TA.Utils.Core
                     return 1;
 
                 // Compare the next segment to see if we can determine inequality.
-                result = CompareSegmentPreferNumericSort(leftSegments[i], rightSegments[i]);
+                var result = CompareSegmentPreferNumericSort(leftSegments[i], rightSegments[i]);
                 if (result != 0)
                     return result;
 
@@ -457,13 +456,13 @@ namespace TA.Utils.Core
         private static int ComparePrereleaseVersions(Maybe<string> leftVersion, Maybe<string> rightVersion)
             {
             // If the prerelease segment is absent in both instances, then they are considered equal.
-            if (leftVersion.None && rightVersion.None)
+            if (leftVersion.IsEmpty && rightVersion.IsEmpty)
                 return 0;
 
             // By definition, a prerelease version is less than the absence of a prerelease version - this is a bit counterintuitive.
-            if (leftVersion.Any() && rightVersion.None)
+            if (leftVersion.Any() && rightVersion.IsEmpty)
                 return -1;
-            if (leftVersion.None && rightVersion.Any())
+            if (leftVersion.IsEmpty && rightVersion.Any())
                 return 1;
             int result = CompareSegmentBySegment(leftVersion.Single(), rightVersion.Single());
             return result;

--- a/TA.Utils.Core/StringExtensions.cs
+++ b/TA.Utils.Core/StringExtensions.cs
@@ -24,6 +24,7 @@ namespace TA.Utils.Core
         /// <returns>
         ///     A new string with all of the unwanted characters deleted. Returns <see cref="string.Empty" />
         ///     if all of the characters were deleted or if the source string was null or empty.
+        ///     Returns the source string if <paramref name="clean"/>
         /// </returns>
         /// <remarks>
         ///     Contrast with <see cref="Keep" />
@@ -31,8 +32,13 @@ namespace TA.Utils.Core
         /// <seealso cref="Keep" />
         public static string Clean(this string source, string clean)
             {
+            // Note: considered converting `clean` to a HashMap<char> because
+            // HashMap.Contains is O(1) whereas String.Contains is O(n).
+            // However, benchmark showed no performance gain until `clean` is at least 25 characters.
             if (string.IsNullOrEmpty(source))
                 return string.Empty;
+            if (string.IsNullOrEmpty(clean))
+                return source;
             var cleanString = new StringBuilder(source.Length);
             foreach (var ch in source)
                 if (!clean.Contains(ch))
@@ -49,6 +55,9 @@ namespace TA.Utils.Core
         /// <exception cref="ArgumentOutOfRangeException">Thrown if the requested number of characters exceeds the string length.</exception>
         public static string Head(this string source, int length)
             {
+            if (source is null) throw new ArgumentNullException(nameof(source));
+            if (length < 0) throw new ArgumentOutOfRangeException(nameof(length));
+            if (length == 0) return string.Empty;
             if (length > source.Length)
                 throw new ArgumentOutOfRangeException(nameof(source),
                     "The specified length is greater than the length of the string.");

--- a/TA.Utils.Core/StringExtensions.cs
+++ b/TA.Utils.Core/StringExtensions.cs
@@ -50,7 +50,7 @@ namespace TA.Utils.Core
         public static string Head(this string source, int length)
             {
             if (length > source.Length)
-                throw new ArgumentOutOfRangeException("source",
+                throw new ArgumentOutOfRangeException(nameof(source),
                     "The specified length is greater than the length of the string.");
             return source.Substring(0, length);
             }
@@ -113,7 +113,7 @@ namespace TA.Utils.Core
             {
             var srcLength = source.Length;
             if (length > srcLength)
-                throw new ArgumentOutOfRangeException("source",
+                throw new ArgumentOutOfRangeException(nameof(source),
                     "The specified length is greater than the length of the string.");
             return source.Substring(srcLength - length, length);
             }

--- a/TA.Utils.Core/StringExtensions.cs
+++ b/TA.Utils.Core/StringExtensions.cs
@@ -1,0 +1,142 @@
+﻿// This file is part of the TA.Utils project
+// Copyright © 2016-2023 Tigra Astronomy, all rights reserved.
+// File: StringExtensions.cs  Last modified: 2023-07-29@12:34 by Tim Long
+
+using System;
+using System.Linq;
+using System.Text;
+
+namespace TA.Utils.Core
+    {
+    /// <summary>
+    ///     String extension methods.
+    /// </summary>
+    /// <remarks>
+    ///     Useful string manipulation convenience methods.
+    /// </remarks>
+    internal static class StringExtensions
+        {
+        /// <summary>
+        ///     Removes all unwanted characters from a string.
+        /// </summary>
+        /// <param name="source">The source string.</param>
+        /// <param name="clean">A list of the unwanted characters. All other characters will be preserved.</param>
+        /// <returns>
+        ///     A new string with all of the unwanted characters deleted. Returns <see cref="string.Empty" />
+        ///     if all of the characters were deleted or if the source string was null or empty.
+        /// </returns>
+        /// <remarks>
+        ///     Contrast with <see cref="Keep" />
+        /// </remarks>
+        /// <seealso cref="Keep" />
+        public static string Clean(this string source, string clean)
+            {
+            if (string.IsNullOrEmpty(source))
+                return string.Empty;
+            var cleanString = new StringBuilder(source.Length);
+            foreach (var ch in source)
+                if (!clean.Contains(ch))
+                    cleanString.Append(ch);
+            return cleanString.ToString();
+            }
+
+        /// <summary>
+        ///     Returns the specified number of characters from the head of a string.
+        /// </summary>
+        /// <param name="source">The source string.</param>
+        /// <param name="length">The number of characters to be returned, must not be greater than the length of the string.</param>
+        /// <returns>The specified number of characters from the head of the source string, as a new string.</returns>
+        /// <exception cref="ArgumentOutOfRangeException">Thrown if the requested number of characters exceeds the string length.</exception>
+        public static string Head(this string source, int length)
+            {
+            if (length > source.Length)
+                throw new ArgumentOutOfRangeException("source",
+                    "The specified length is greater than the length of the string.");
+            return source.Substring(0, length);
+            }
+
+        /// <summary>
+        ///     Keeps only the wanted (that is, removes all unwanted characters) from the string.
+        /// </summary>
+        /// <param name="source">The source string.</param>
+        /// <param name="keep">A list of the wanted characters. All other characters will be removed.</param>
+        /// <returns>
+        ///     A new string with all of the unwanted characters deleted. Returns <see cref="string.Empty" /> if all
+        ///     the characters were deleted or if the source string was null or empty.
+        /// </returns>
+        /// <seealso cref="Clean" />
+        public static string Keep(this string source, string keep)
+            {
+            if (string.IsNullOrEmpty(source))
+                return string.Empty;
+            var cleanString = new StringBuilder(source.Length);
+            foreach (var ch in source)
+                if (keep.Contains(ch))
+                    cleanString.Append(ch);
+            return cleanString.ToString();
+            }
+
+        /// <summary>
+        ///     Remove the head of the string, leaving the tail.
+        /// </summary>
+        /// <param name="source">The source string.</param>
+        /// <param name="length">Number of characters to remove from the head.</param>
+        /// <returns>A new string containing the old string with <paramref name="length" /> characters removed from the head.</returns>
+        public static string RemoveHead(this string source, int length)
+            {
+            if (length < 1)
+                return source;
+            return source.Tail(source.Length - length);
+            }
+
+        /// <summary>
+        ///     Remove the tail of the string, leaving the head.
+        /// </summary>
+        /// <param name="source">The source string.</param>
+        /// <param name="length">Number of characters to remove from the tail.</param>
+        /// <returns>A new string containing the old string with <paramref name="length" /> characters removed from the tail.</returns>
+        public static string RemoveTail(this string source, int length)
+            {
+            if (length < 1)
+                return source;
+            return source.Head(source.Length - length);
+            }
+
+        /// <summary>
+        ///     Returns the specified number of characters from the tail of a string.
+        /// </summary>
+        /// <param name="source">The source string.</param>
+        /// <param name="length">The number of characters to be returned, must not be greater than the length of the string.</param>
+        /// <returns>The specified number of characters from the tail of the source string, as a new string.</returns>
+        /// <exception cref="ArgumentOutOfRangeException">Thrown if the requested number of characters exceeds the string length.</exception>
+        public static string Tail(this string source, int length)
+            {
+            var srcLength = source.Length;
+            if (length > srcLength)
+                throw new ArgumentOutOfRangeException("source",
+                    "The specified length is greater than the length of the string.");
+            return source.Substring(srcLength - length, length);
+            }
+
+        /// <summary>
+        ///     Converts a tring to a hex representation, suitable for display in a debugger.
+        /// </summary>
+        /// <param name="source">The source string.</param>
+        /// <returns>A new string showing each character of the source string as a hex digit.</returns>
+        public static string ToHex(this string source)
+            {
+            const string formatWithSeperator = ", {0,2:x}";
+            const string formatNoSeperator = "{0,2:x}";
+            var hexString = new StringBuilder(source.Length * 7);
+            hexString.Append('{');
+            var seperator = false;
+            foreach (var ch in source)
+                {
+                hexString.AppendFormat(seperator ? formatWithSeperator : formatNoSeperator, (int)ch);
+                seperator = true;
+                }
+            hexString.Append('}');
+            return hexString.ToString();
+            }
+        }
+    }

--- a/TA.Utils.Core/TA.Utils.Core.csproj
+++ b/TA.Utils.Core/TA.Utils.Core.csproj
@@ -35,6 +35,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
+    <PackageReference Include="JetBrains.Annotations" Version="2023.2.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/TA.Utils.Core/TA.Utils.Core.xml
+++ b/TA.Utils.Core/TA.Utils.Core.xml
@@ -383,6 +383,11 @@
             <value>The git patch version, as a string.</value>
             <seealso cref="T:TA.Utils.Core.SemanticVersion" />
         </member>
+        <member name="P:TA.Utils.Core.GitVersion.GitBranchName">
+            <summary>Gets the name of the git branch from which the assembly was built.</summary>
+            <value>The git branch name, as a string.</value>
+            <seealso cref="T:TA.Utils.Core.SemanticVersion" />
+        </member>
         <member name="M:TA.Utils.Core.GitVersion.GitVersionField(System.Type,System.String)">
             <summary>Uses reflection to fetch the value of a member field of the injected version information.</summary>
             <param name="gitVersionInformationType">Type of the git version information.</param>

--- a/TA.Utils.Core/TA.Utils.Core.xml
+++ b/TA.Utils.Core/TA.Utils.Core.xml
@@ -333,7 +333,7 @@
             </summary>
             <seealso cref="T:TA.Utils.Core.SemanticVersion" />
         </member>
-        <member name="F:TA.Utils.Core.GitVersion.InjectedVersion">
+        <member name="F:TA.Utils.Core.GitVersion.injectedVersion">
             <summary>The type injected by GitVersion during the build process, containing version information.</summary>
         </member>
         <member name="P:TA.Utils.Core.GitVersion.GitInformationalVersion">
@@ -387,6 +387,11 @@
             <summary>Gets the name of the git branch from which the assembly was built.</summary>
             <value>The git branch name, as a string.</value>
             <seealso cref="T:TA.Utils.Core.SemanticVersion" />
+        </member>
+        <member name="M:TA.Utils.Core.GitVersion.UnitTestNullInjectedVersionType">
+            <summary>
+                A method intended to be used for unit testing to set the injected version type to null. [#2]
+            </summary>
         </member>
         <member name="M:TA.Utils.Core.GitVersion.GitVersionField(System.Type,System.String)">
             <summary>Uses reflection to fetch the value of a member field of the injected version information.</summary>

--- a/TA.Utils.Core/TA.Utils.Core.xml
+++ b/TA.Utils.Core/TA.Utils.Core.xml
@@ -952,7 +952,7 @@
             <returns>
                 A new string with all of the unwanted characters deleted. Returns <see cref="F:System.String.Empty" />
                 if all of the characters were deleted or if the source string was null or empty.
-                Returns the source string if <paramref name="clean" /> is null or empty.
+                Returns the source string if <paramref name="clean"/>
             </returns>
             <remarks>
                 Contrast with <see cref="M:TA.Utils.Core.StringExtensions.Keep(System.String,System.String)" />

--- a/TA.Utils.Core/TA.Utils.Core.xml
+++ b/TA.Utils.Core/TA.Utils.Core.xml
@@ -159,139 +159,151 @@
         <member name="M:TA.Utils.Core.Diagnostics.DegenerateLoggerService.WithAmbientProperty(System.String,System.Object)">
             <inheritdoc />
         </member>
+        <member name="M:TA.Utils.Core.Diagnostics.DegenerateLoggerService.WithName(System.String)">
+            <inheritdoc />
+        </member>
         <member name="T:TA.Utils.Core.Diagnostics.IFluentLogBuilder">
             <summary>
-            Fluent Log Builder
+                Fluent Log Builder
             </summary>
         </member>
         <member name="M:TA.Utils.Core.Diagnostics.IFluentLogBuilder.Exception(System.Exception)">
             <summary>
-            Add an exception to the log entry.
+                Add an exception to the log entry.
             </summary>
         </member>
         <member name="M:TA.Utils.Core.Diagnostics.IFluentLogBuilder.LoggerName(System.String)">
             <summary>
-            Set the log (source) name. By default, this is the name of the source file.
+                Set the log (source) name. By default, this is usually the name of the class or source file.
             </summary>
         </member>
         <member name="M:TA.Utils.Core.Diagnostics.IFluentLogBuilder.Message(System.String)">
             <summary>
-            Sets the message template for the log entry.
-            The message may be a simple plain text string,
-            it may contain numbered substitution tokens like string.Format,
-            or it may contain named substitution tokens enclosed in {braces}
+                Sets the message template for the log entry.
+                The message may be a simple plain text string,
+                it may contain numbered substitution tokens like string.Format,
+                or it may contain named substitution tokens enclosed in {braces}
             </summary>
         </member>
         <member name="M:TA.Utils.Core.Diagnostics.IFluentLogBuilder.Message(System.String,System.Object[])">
             <summary>
-            Sets the message template and property values for the log entry.
-            The format string may use numbered positional placeholders like string.Format,
-            or it may contain named substitution tokens enclosed in {braces}.
+                Sets the message template and property values for the log entry.
+                The format string may use numbered positional placeholders like string.Format,
+                or it may contain named substitution tokens enclosed in {braces}.
             </summary>
         </member>
         <member name="M:TA.Utils.Core.Diagnostics.IFluentLogBuilder.Message(System.IFormatProvider,System.String,System.Object[])">
             <summary>
-            Sets the message template and property values for the log entry.
-            The format provider will be used when rendering the property values.
+                Sets the message template and property values for the log entry.
+                The format provider will be used when rendering the property values.
             </summary>
         </member>
         <member name="M:TA.Utils.Core.Diagnostics.IFluentLogBuilder.Property(System.String,System.Object)">
             <summary>
-            Adds a named property and value pair to the log entry.
+                Adds a named property and value pair to the log entry.
             </summary>
         </member>
         <member name="M:TA.Utils.Core.Diagnostics.IFluentLogBuilder.Properties(System.Collections.Generic.IDictionary{System.String,System.Object})">
             <summary>
-            Adds a collection of property/value pairs to the log entry.
+                Adds a collection of property/value pairs to the log entry.
             </summary>
         </member>
         <member name="M:TA.Utils.Core.Diagnostics.IFluentLogBuilder.TimeStamp(System.DateTime)">
             <summary>
-            Sets the time stamp of the log entry.
-            If not set, the log entry will be timed at the moment Write() was called.
+                Sets the time stamp of the log entry.
+                If not set, the log entry will be timed at the moment Write() was called.
             </summary>
         </member>
         <member name="M:TA.Utils.Core.Diagnostics.IFluentLogBuilder.StackTrace(System.Diagnostics.StackTrace,System.Int32)">
             <summary>
-            Adds a stack trace to the log entry.
+                Adds a stack trace to the log entry.
             </summary>
         </member>
         <member name="M:TA.Utils.Core.Diagnostics.IFluentLogBuilder.Write(System.String,System.String,System.Int32)">
             <summary>
-            Writes the log entry.
+                Writes the log entry.
             </summary>
         </member>
         <member name="M:TA.Utils.Core.Diagnostics.IFluentLogBuilder.WriteIf(System.Func{System.Boolean},System.String,System.String,System.Int32)">
             <summary>
-            Writes the log entry if the supplied predicate is true.
+                Writes the log entry if the supplied predicate is true.
             </summary>
         </member>
         <member name="M:TA.Utils.Core.Diagnostics.IFluentLogBuilder.WriteIf(System.Boolean,System.String,System.String,System.Int32)">
             <summary>
-            Writes the log entry if the boolean condition is true.
+                Writes the log entry if the boolean condition is true.
             </summary>
         </member>
         <member name="T:TA.Utils.Core.Diagnostics.ILog">
             <summary>
-            Logging service interface
+                Logging service interface
             </summary>
         </member>
         <member name="M:TA.Utils.Core.Diagnostics.ILog.Trace(System.String)">
             <summary>
-            Creates a log builder for a log entry with Trace severity.
+                Creates a log builder for a log entry with Trace severity.
             </summary>
             <param name="callerFilePath">The caller file path.</param>
             <returns>IFluentLogBuilder.</returns>
         </member>
         <member name="M:TA.Utils.Core.Diagnostics.ILog.Debug(System.String)">
             <summary>
-            Creates a log builder for a log entry with Debug severity.
+                Creates a log builder for a log entry with Debug severity.
             </summary>
             <param name="callerFilePath">The caller file path.</param>
             <returns>IFluentLogBuilder.</returns>
         </member>
         <member name="M:TA.Utils.Core.Diagnostics.ILog.Info(System.String)">
             <summary>
-            Creates a log builder for a log entry with Information severity.
+                Creates a log builder for a log entry with Information severity.
             </summary>
             <param name="callerFilePath">The caller file path.</param>
             <returns>IFluentLogBuilder.</returns>
         </member>
         <member name="M:TA.Utils.Core.Diagnostics.ILog.Warn(System.String)">
             <summary>
-            Creates a log builder for a log entry with Warning severity.
+                Creates a log builder for a log entry with Warning severity.
             </summary>
             <param name="callerFilePath">The caller file path.</param>
             <returns>IFluentLogBuilder.</returns>
         </member>
         <member name="M:TA.Utils.Core.Diagnostics.ILog.Error(System.String)">
             <summary>
-            Creates a log builder for a log entry with Error severity.
+                Creates a log builder for a log entry with Error severity.
             </summary>
             <param name="callerFilePath">The caller file path.</param>
             <returns>IFluentLogBuilder.</returns>
         </member>
         <member name="M:TA.Utils.Core.Diagnostics.ILog.Fatal(System.String)">
             <summary>
-            Creates a log builder for a log entry with Fatal severity.
-            Writing a Fatal log entry also terminates the process.
+                Creates a log builder for a log entry with Fatal severity.
+                Writing a Fatal log entry also terminates the process.
             </summary>
             <param name="callerFilePath">The caller file path.</param>
             <returns>IFluentLogBuilder.</returns>
         </member>
         <member name="M:TA.Utils.Core.Diagnostics.ILog.Shutdown">
             <summary>
-            Instructs the logging service to shut down.
-            This should flush any buffered log entries and close any open files or streams.
-            It is best practice to call <c>Shutdown</c> before exiting from the program.
+                Instructs the logging service to shut down.
+                This should flush any buffered log entries and close any open files or streams.
+                It is best practice to call <c>Shutdown</c> before exiting from the program.
             </summary>
         </member>
         <member name="M:TA.Utils.Core.Diagnostics.ILog.WithAmbientProperty(System.String,System.Object)">
             <summary>
-            Sets an "ambient property" that should be included in all log events.
-            Once added, the property persists for the lifetim of the instance.
-            Useful for loggers that support semantic logging.
+                Sets an "ambient property" that should be included in all log events.
+                Once added, the property persists for the lifetim of the instance.
+                Useful for loggers that support semantic logging.
             </summary>
+        </member>
+        <member name="M:TA.Utils.Core.Diagnostics.ILog.WithName(System.String)">
+            <summary>
+            Sets the name of the logger, which can be used by a logging back-end for filtering and routing
+            of log entries. If unset, then the value is implementation dependent and may default to the name
+            of the class or source file where the ILog instance is created or injected, or some other value.
+            </summary>
+            <param name="logSourceName"></param>
+            <returns></returns>
         </member>
         <member name="T:TA.Utils.Core.DisplayEquivalentAttribute">
             <summary>
@@ -443,6 +455,10 @@
             <summary>Gets a value indicating whether this <see cref="T:TA.Utils.Core.Maybe`1" /> is empty (has no value).</summary>
             <value><c>true</c> if none; otherwise, <c>false</c>.</value>
         </member>
+        <member name="P:TA.Utils.Core.Maybe`1.IsEmpty">
+            <summary>Gets a value indicating whether this <see cref="T:TA.Utils.Core.Maybe`1" /> is empty (has no value).</summary>
+            <value><c>true</c> if there is no value; otherwise, <c>false</c>.</value>
+        </member>
         <member name="M:TA.Utils.Core.Maybe`1.GetEnumerator">
             <summary>Returns an enumerator that iterates through the collection.</summary>
             <returns>
@@ -545,12 +561,30 @@
             <param name="value">The value of the specified bit number.</param>
             <returns>A new octet instance with the specified bit number set to the specified value.</returns>
         </member>
+        <member name="M:TA.Utils.Core.Octet.WithBitSet(System.Int32)">
+            <summary>
+                Returns a new Octet instance with the specified bit set to 1. Other bits are duplicated from the current instance.
+            </summary>
+            <param name="bitNumber">
+                The bit position to be set, where 0 is the least significant bit and 7 is the most significant
+                bit.
+            </param>
+            <returns>A new Octet instance with the specified bit set to 1.</returns>
+            <exception cref="T:System.ArgumentOutOfRangeException">Thrown when bitNumber is less than 0 or greater than 7.</exception>
+        </member>
+        <member name="M:TA.Utils.Core.Octet.WithBitClear(System.Int32)">
+            <summary>
+                Returns a new Octet instance with the specified bit number cleared (set to false). Other bits are unchanged.
+            </summary>
+            <param name="bitNumber">The bit number to be cleared. Must be between 0 and 7 inclusive.</param>
+            <returns>A new Octet instance with the specified bit number cleared.</returns>
+        </member>
         <member name="M:TA.Utils.Core.Octet.WithBitSetTo(System.Int32,System.Boolean)">
             <summary>
                 Returns a new octet with the specified bit number set to the specified value. Other bits are
                 duplicated.
             </summary>
-            <param name="bit">The bit number to be modified.</param>
+            <param name="bitNumber">The bit number to be modified.</param>
             <param name="value">The value of the specified bit number.</param>
             <returns>A new octet instance with the specified bit number set to the specified value.</returns>
         </member>
@@ -898,6 +932,82 @@
             <returns><c>true</c> if the left version is greater than or equal to the right version.</returns>
             <seealso cref="M:TA.Utils.Core.SemanticVersion.CompareTo(TA.Utils.Core.SemanticVersion)"/>
             <seealso cref="M:TA.Utils.Core.SemanticVersion.Equals(TA.Utils.Core.SemanticVersion)"/>
+        </member>
+        <member name="T:TA.Utils.Core.StringExtensions">
+            <summary>
+                String extension methods.
+            </summary>
+            <remarks>
+                Useful string manipulation convenience methods.
+            </remarks>
+        </member>
+        <member name="M:TA.Utils.Core.StringExtensions.Clean(System.String,System.String)">
+            <summary>
+                Removes all unwanted characters from a string.
+            </summary>
+            <param name="source">The source string.</param>
+            <param name="clean">A list of the unwanted characters. All other characters will be preserved.</param>
+            <returns>
+                A new string with all of the unwanted characters deleted. Returns <see cref="F:System.String.Empty" />
+                if all of the characters were deleted or if the source string was null or empty.
+            </returns>
+            <remarks>
+                Contrast with <see cref="M:TA.Utils.Core.StringExtensions.Keep(System.String,System.String)" />
+            </remarks>
+            <seealso cref="M:TA.Utils.Core.StringExtensions.Keep(System.String,System.String)" />
+        </member>
+        <member name="M:TA.Utils.Core.StringExtensions.Head(System.String,System.Int32)">
+            <summary>
+                Returns the specified number of characters from the head of a string.
+            </summary>
+            <param name="source">The source string.</param>
+            <param name="length">The number of characters to be returned, must not be greater than the length of the string.</param>
+            <returns>The specified number of characters from the head of the source string, as a new string.</returns>
+            <exception cref="T:System.ArgumentOutOfRangeException">Thrown if the requested number of characters exceeds the string length.</exception>
+        </member>
+        <member name="M:TA.Utils.Core.StringExtensions.Keep(System.String,System.String)">
+            <summary>
+                Keeps only the wanted (that is, removes all unwanted characters) from the string.
+            </summary>
+            <param name="source">The source string.</param>
+            <param name="keep">A list of the wanted characters. All other characters will be removed.</param>
+            <returns>
+                A new string with all of the unwanted characters deleted. Returns <see cref="F:System.String.Empty" /> if all
+                the characters were deleted or if the source string was null or empty.
+            </returns>
+            <seealso cref="M:TA.Utils.Core.StringExtensions.Clean(System.String,System.String)" />
+        </member>
+        <member name="M:TA.Utils.Core.StringExtensions.RemoveHead(System.String,System.Int32)">
+            <summary>
+                Remove the head of the string, leaving the tail.
+            </summary>
+            <param name="source">The source string.</param>
+            <param name="length">Number of characters to remove from the head.</param>
+            <returns>A new string containing the old string with <paramref name="length" /> characters removed from the head.</returns>
+        </member>
+        <member name="M:TA.Utils.Core.StringExtensions.RemoveTail(System.String,System.Int32)">
+            <summary>
+                Remove the tail of the string, leaving the head.
+            </summary>
+            <param name="source">The source string.</param>
+            <param name="length">Number of characters to remove from the tail.</param>
+            <returns>A new string containing the old string with <paramref name="length" /> characters removed from the tail.</returns>
+        </member>
+        <member name="M:TA.Utils.Core.StringExtensions.Tail(System.String,System.Int32)">
+            <summary>
+                Returns the specified number of characters from the tail of a string.
+            </summary>
+            <param name="source">The source string.</param>
+            <param name="length">The number of characters to be returned, must not be greater than the length of the string.</param>
+            <returns>The specified number of characters from the tail of the source string, as a new string.</returns>
+            <exception cref="T:System.ArgumentOutOfRangeException">Thrown if the requested number of characters exceeds the string length.</exception>
+        </member>
+        <member name="M:TA.Utils.Core.StringExtensions.ToHex(System.String)">
+            <summary>
+                Converts a tring to a hex representation, suitable for display in a debugger.
+            </summary>
+            <param name="source">The source string.</param>
+            <returns>A new string showing each character of the source string as a hex digit.</returns>
         </member>
     </members>
 </doc>

--- a/TA.Utils.Core/TA.Utils.Core.xml
+++ b/TA.Utils.Core/TA.Utils.Core.xml
@@ -51,9 +51,11 @@
         </member>
         <member name="M:TA.Utils.Core.AsyncExtensions.ContinueOnAnyThread(System.Threading.Tasks.Task)">
             <summary>
-                Configures a task to schedule its completion on any available thread. Use this when awaiting
+                Configures a task awaiter to schedule its completion on any available thread. Use this when awaiting
                 tasks in a user interface thread to avoid deadlock issues.
-                This is the recommended best practice for library writers.
+                This is the recommended best practice for general purpose library writers.
+                There is no need to post library internal async operations back to the UI thread,
+                and doing so could potentially lead to a deadlock if the UI thread is blocked.
             </summary>
             <param name="task">The task to configure.</param>
             <returns>An awaitable object that may schedule continuation on any thread.</returns>
@@ -78,8 +80,8 @@
                 execute on the same thread. However in a free threaded context, the continuation can
                 still happen on a different thread. This can be risky when the awaiter is a single
                 threaded apartment (STA) thread. If the awaiter blocks waiting for the task, then
-                the continuation may never execute, preventign completion and resulting in deadlock.
-                Use with care.
+                the continuation may never execute, preventing completion and resulting in deadlock.
+                Use with care, especially in general purpose libraries.
             </summary>
             <param name="task">The task.</param>
             <returns>ConfiguredTaskAwaitable.</returns>
@@ -950,6 +952,7 @@
             <returns>
                 A new string with all of the unwanted characters deleted. Returns <see cref="F:System.String.Empty" />
                 if all of the characters were deleted or if the source string was null or empty.
+                Returns the source string if <paramref name="clean" /> is null or empty.
             </returns>
             <remarks>
                 Contrast with <see cref="M:TA.Utils.Core.StringExtensions.Keep(System.String,System.String)" />

--- a/TA.Utils.Logging.NLog.SampleConsoleApp/Program.cs
+++ b/TA.Utils.Logging.NLog.SampleConsoleApp/Program.cs
@@ -6,6 +6,7 @@ using System;
 using System.Collections.Generic;
 using System.Threading.Tasks;
 using TA.Utils.Core;
+using TA.Utils.Core.Diagnostics;
 
 namespace TA.Utils.Logging.NLog.SampleConsoleApp
     {
@@ -23,7 +24,7 @@ namespace TA.Utils.Logging.NLog.SampleConsoleApp
         {
         static readonly List<int> SuperstitiousNumbers = new List<int> {13, 7, 666, 3, 8, 88, 888};
 
-        async static Task Main(string[] args)
+        static async Task Main(string[] args)
             {
             var log = new LoggingService();
             log.Info()

--- a/TA.Utils.Logging.Nlog/LogBuilder.cs
+++ b/TA.Utils.Logging.Nlog/LogBuilder.cs
@@ -3,7 +3,6 @@
 // File: NLogLogBuilder.cs  Last modified: 2020-07-14@03:27 by Tim Long
 
 using System;
-using System.Collections;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Linq;
@@ -88,28 +87,7 @@ namespace TA.Utils.Logging.NLog
             return this;
         }
 
-        /// <inheritdoc />
-        public IFluentLogBuilder Property(object name, object value)
-        {
-            if (name == null)
-                throw new ArgumentNullException(nameof(name));
-            logEvent.Properties[name] = value;
-            return this;
-        }
-
-        /// <inheritdoc />
-        public IFluentLogBuilder Properties(IDictionary properties)
-        {
-            if (properties == null)
-                throw new ArgumentNullException(nameof(properties));
-            foreach (var key in properties.Keys)
-            {
-                logEvent.Properties[key] = properties[key];
-            }
-            return this;
-        }
-
-        /// <inheritdoc />
+    /// <inheritdoc />
         public IFluentLogBuilder TimeStamp(DateTime timeStamp)
         {
             logEvent.TimeStamp = timeStamp;

--- a/TA.Utils.Logging.Nlog/LoggingService.cs
+++ b/TA.Utils.Logging.Nlog/LoggingService.cs
@@ -1,6 +1,6 @@
 ﻿// This file is part of the TA.Utils project
-// Copyright © 2016-2020 Tigra Astronomy, all rights reserved.
-// File: LoggingService.cs  Last modified: 2020-07-16@20:09 by Tim Long
+// Copyright © 2016-2023 Timtek Systems Limited, all rights reserved.
+// File: LoggingService.cs  Last modified: 2023-08-13@23:30 by Tim Long
 
 using System.Collections.Generic;
 using System.IO;
@@ -9,101 +9,104 @@ using NLog;
 using TA.Utils.Core.Diagnostics;
 
 namespace TA.Utils.Logging.NLog
-{
+    {
     /// <summary>
     ///     A logging service that uses NLog as the back-end logger. Implements the
     ///     <see cref="TA.Utils.Core.Diagnostics.ILog" />
     /// </summary>
     /// <seealso cref="TA.Utils.Core.Diagnostics.ILog" />
     public sealed class LoggingService : ILog
-    {
+        {
         private static readonly ILogger DefaultLogger = LogManager.GetCurrentClassLogger();
-        private IDictionary<string, object> ambientProperties = new Dictionary<string, object>();
+        private readonly IDictionary<string, object> ambientProperties = new Dictionary<string, object>();
         private string sourceName = string.Empty;
 
         /// <summary>Static initializer can be used to perform 1-time NLog configurations.</summary>
         static LoggingService()
-        {
+            {
             LogManager.AutoShutdown = true;
-        }
+            }
 
         /// <inheritdoc />
         public IFluentLogBuilder Trace([CallerFilePath] string callerFilePath = null)
-        {
+            {
             return CreateLogBuilder(LogLevel.Trace, callerFilePath);
-        }
+            }
 
         /// <inheritdoc />
         public IFluentLogBuilder Debug([CallerFilePath] string callerFilePath = null)
-        {
+            {
             return CreateLogBuilder(LogLevel.Debug, callerFilePath);
-        }
+            }
 
         /// <inheritdoc />
         public IFluentLogBuilder Info([CallerFilePath] string callerFilePath = null)
-        {
+            {
             return CreateLogBuilder(LogLevel.Info, callerFilePath);
-        }
+            }
 
         /// <inheritdoc />
         public IFluentLogBuilder Warn([CallerFilePath] string callerFilePath = null)
-        {
+            {
             return CreateLogBuilder(LogLevel.Warn, callerFilePath);
-        }
+            }
 
         /// <inheritdoc />
         public IFluentLogBuilder Error([CallerFilePath] string callerFilePath = null)
-        {
+            {
             return CreateLogBuilder(LogLevel.Error, callerFilePath);
-        }
+            }
 
         /// <inheritdoc />
         public IFluentLogBuilder Fatal([CallerFilePath] string callerFilePath = null)
-        {
+            {
             return CreateLogBuilder(LogLevel.Fatal, callerFilePath);
-        }
+            }
+
+        /// <inheritdoc />
+        public void Shutdown()
+            {
+            LogManager.Shutdown();
+            }
+
+        /// <inheritdoc />
+        public ILog WithAmbientProperty(string name, object value)
+            {
+            ambientProperties[name] = value;
+            return this;
+            }
+
+        /// <inheritdoc />
+        public ILog WithName(string logSourceName)
+            {
+            sourceName = logSourceName;
+            return this;
+            }
 
         private IFluentLogBuilder CreateLogBuilder(LogLevel logLevel, string callerFilePath)
-        {
+            {
             var name = GetLoggerName(callerFilePath);
             var logger = string.IsNullOrWhiteSpace(name) ? DefaultLogger : LogManager.GetLogger(name);
             var builder = new LogBuilder(logger, logLevel, ambientProperties);
             return builder;
-        }
+            }
 
-    /// <summary>
-    /// Gets the name for this logger instance.
-    /// Any explicitly set user preference takes priority.
-    /// Otherwise, we try to build a logger name from the caller file path.
-    /// If all else fails, we return <see cref="string.Empty"/>.
-    /// </summary>
-    /// <param name="callerFilePath">The name of the caller's source file, if known.</param>
-    /// <returns>A string containing the suggested logger name.</returns>
+        /// <summary>
+        ///     Gets the name for this logger instance.
+        ///     Any explicitly set user preference takes priority.
+        ///     Otherwise, we try to build a logger name from the caller file path.
+        ///     If all else fails, we return <see cref="string.Empty" />.
+        /// </summary>
+        /// <param name="callerFilePath">The name of the caller's source file, if known.</param>
+        /// <returns>A string containing the suggested logger name.</returns>
         private string GetLoggerName(string callerFilePath)
-        {
-            if (!string.IsNullOrWhiteSpace(sourceName)) 
+            {
+            if (!string.IsNullOrWhiteSpace(sourceName))
                 return sourceName;
             var name = !string.IsNullOrWhiteSpace(callerFilePath)
                 ? Path.GetFileNameWithoutExtension(callerFilePath)
                 : string.Empty;
             return name;
-        }
-
-    /// <inheritdoc />
-        public void Shutdown() => LogManager.Shutdown();
-
-        /// <inheritdoc />
-        public ILog WithAmbientProperty(string name, object value)
-        {
-            ambientProperties[name] = value;
-            return this;
-        }
-
-    /// <inheritdoc />
-    public ILog WithName(string logSourceName)
-        {
-        this.sourceName = logSourceName;
-        return this;
+            }
         }
     }
-}

--- a/TA.Utils.Specifications/GitVersionSpecs.cs
+++ b/TA.Utils.Specifications/GitVersionSpecs.cs
@@ -1,0 +1,31 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Machine.Specifications;
+using TA.Utils.Core;
+
+namespace TA.Utils.Specifications
+    {
+        class with_gitversion_null_entry_assembly
+        {
+            Establish context = () => GitVersion.UnitTestNullInjectedVersionType();
+        }
+
+        class when_retrieving_version_information : with_gitversion_null_entry_assembly
+        {
+            It should_report_default_full_semantic_version = () => GitVersion.GitFullSemVer.ShouldEqual("0.0.0-unversioned");
+            It should_report_default_semantic_version = () => GitVersion.GitSemVer.ShouldEqual("0.0.0");
+            It should_report_default_major_version = () => GitVersion.GitMajorVersion.ShouldEqual("0");
+            It should_report_default_minor_version = () => GitVersion.GitMinorVersion.ShouldEqual("0");
+            It should_report_default_patch_version = () => GitVersion.GitPatchVersion.ShouldEqual("0");
+            It should_report_empty_branch_name = () => GitVersion.GitBranchName.ShouldBeEmpty();
+            It should_report_empty_metadata = () => GitVersion.GitBuildMetadata.ShouldBeEmpty();
+            It should_report_empty_commit_date = () => GitVersion.GitCommitDate.ShouldBeEmpty();
+            It should_report_empty_commit_hash = () => GitVersion.GitCommitSha.ShouldBeEmpty();
+            It should_report_empty_commit_short_hash = () => GitVersion.GitCommitShortSha.ShouldBeEmpty();
+            It should_report_default_info_version = () => GitVersion.GitInformationalVersion.ShouldEqual(GitVersion.GitFullSemVer);
+            
+        }
+    }

--- a/TA.Utils.Specifications/GitVersionSpecs.cs
+++ b/TA.Utils.Specifications/GitVersionSpecs.cs
@@ -1,9 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
-using Machine.Specifications;
+﻿using Machine.Specifications;
 using TA.Utils.Core;
 
 namespace TA.Utils.Specifications

--- a/TA.Utils.Specifications/MathExtensionSpecs.cs
+++ b/TA.Utils.Specifications/MathExtensionSpecs.cs
@@ -2,6 +2,7 @@
 // Copyright © 2016-2020 Tigra Astronomy, all rights reserved.
 // File: MathExtensionSpecs.cs  Last modified: 2020-07-13@02:11 by Tim Long
 
+using JetBrains.Annotations;
 using Machine.Specifications;
 using TA.Utils.Core;
 
@@ -10,8 +11,8 @@ namespace TA.Utils.Specifications
     #region Context base classes
     class with_clip_test_context
         {
-        protected static SemanticVersion MaximumVersion = new SemanticVersion("9.8.7");
-        protected static SemanticVersion MinimumVersion = new SemanticVersion("3.2.1");
+        [UsedImplicitly] protected static readonly SemanticVersion MaximumVersion = new("9.8.7");
+        [UsedImplicitly] protected static readonly SemanticVersion MinimumVersion = new("3.2.1");
         }
     #endregion
 
@@ -19,20 +20,20 @@ namespace TA.Utils.Specifications
     internal class when_clipping_a_value_above_maximum : with_clip_test_context
         {
         It should_clip_at_maximum = () => testCase.Clip(MinimumVersion, MaximumVersion).ShouldEqual(MaximumVersion);
-        static SemanticVersion testCase = new SemanticVersion("9.8.8");
+        static SemanticVersion testCase = new("9.8.8");
         }
 
     [Subject(typeof(MathExtensions))]
     internal class when_clipping_a_value_below_minimum : with_clip_test_context
         {
         It should_clip_at_minimum = () => testCase.Clip(MinimumVersion, MaximumVersion).ShouldEqual(MinimumVersion);
-        static SemanticVersion testCase = new SemanticVersion("1.0.0");
+        static SemanticVersion testCase = new("1.0.0");
         }
 
     [Subject(typeof(MathExtensions))]
     internal class when_clipping_a_value_within_range : with_clip_test_context
         {
         It should_not_clip = () => testCase.Clip(MinimumVersion, MaximumVersion).ShouldEqual(testCase);
-        static SemanticVersion testCase = new SemanticVersion("4.5.6");
+        static SemanticVersion testCase = new("4.5.6");
         }
     }

--- a/TA.Utils.Specifications/MaybeSpecs.cs
+++ b/TA.Utils.Specifications/MaybeSpecs.cs
@@ -2,6 +2,7 @@
 // Copyright © 2016-2020 Tigra Astronomy, all rights reserved.
 // File: MaybeSpecs.cs  Last modified: 2020-07-13@02:11 by Tim Long
 
+using System;
 using System.Linq;
 using Machine.Specifications;
 using TA.Utils.Core;
@@ -25,5 +26,12 @@ namespace TA.Utils.Specifications
         It should_contain_the_source_object = () => maybe.Single().ShouldBeTheSameAs(source);
         static Maybe<object> maybe;
         static object source = new object();
+        }
+
+    class when_calling_single_on_an_empty_maybe
+        {
+        private Because of = () => exception = Catch.Exception(() => Maybe<int>.Empty.Single());
+        private It should_throw_invalid_operation_exception = () => exception.ShouldBeOfExactType<InvalidOperationException>();
+        private static Exception exception;
         }
     }

--- a/TA.Utils.Specifications/MaybeSpecs.cs
+++ b/TA.Utils.Specifications/MaybeSpecs.cs
@@ -22,10 +22,10 @@ namespace TA.Utils.Specifications
         {
         Because of = () => maybe = source.AsMaybe();
         It should_have_content = () => maybe.Any().ShouldBeTrue();
-        It should_not_be_empty = () => maybe.None.ShouldBeFalse();
+        It should_not_be_empty = () => maybe.IsEmpty.ShouldBeFalse();
         It should_contain_the_source_object = () => maybe.Single().ShouldBeTheSameAs(source);
         static Maybe<object> maybe;
-        static object source = new object();
+        static object source = new();
         }
 
     class when_calling_single_on_an_empty_maybe

--- a/TA.Utils.Specifications/NLogLogServiceSpecs.cs
+++ b/TA.Utils.Specifications/NLogLogServiceSpecs.cs
@@ -31,6 +31,7 @@ namespace TA.Utils.Specifications
 
     internal class when_creating_a_named_logger : with_caller_info_context
         {
+        // ReSharper disable once ExplicitCallerInfoArgument
         Establish context = () => builder = (LogBuilder)new LoggingService().Info("Roger");
         It should_change_the_name = () => builder.Build().LoggerName.ShouldEqual("Roger");
         static LogBuilder builder;
@@ -38,6 +39,7 @@ namespace TA.Utils.Specifications
 
     internal class when_creating_and_building_a_named_logger : with_caller_info_context
         {
+        // ReSharper disable once ExplicitCallerInfoArgument
         Establish context = () => builder = (LogBuilder)new LoggingService().Info("Roger");
         Because of = () => builder.LoggerName("Jim");
         It should_change_the_name = () => builder.Build().LoggerName.ShouldEqual("Jim");

--- a/TA.Utils.Specifications/NLogLogServiceSpecs.cs
+++ b/TA.Utils.Specifications/NLogLogServiceSpecs.cs
@@ -8,55 +8,58 @@ using Machine.Specifications;
 using TA.Utils.Core.Diagnostics;
 using TA.Utils.Logging.NLog;
 
-internal class with_caller_info_context
+namespace TA.Utils.Specifications
     {
-    protected static string CallerFileNameWithoutExtenstion([CallerFilePath] string callerFilePath = null)
+    internal class with_caller_info_context
         {
-        const string unknown = "(unknown)";
-        if (string.IsNullOrWhiteSpace(callerFilePath))
-            return unknown;
-        var fileName = Path.GetFileNameWithoutExtension(callerFilePath);
-        return string.IsNullOrWhiteSpace(fileName) ? unknown : fileName;
+        protected static string CallerFileNameWithoutExtenstion([CallerFilePath] string callerFilePath = null)
+            {
+            const string unknown = "(unknown)";
+            if (string.IsNullOrWhiteSpace(callerFilePath))
+                return unknown;
+            var fileName = Path.GetFileNameWithoutExtension(callerFilePath);
+            return string.IsNullOrWhiteSpace(fileName) ? unknown : fileName;
+            }
         }
-    }
 
-internal class when_building_a_default_logger : with_caller_info_context
-    {
-    Establish context = () => builder = (LogBuilder) new LoggingService().Info();
-    It should_have_the_file_name = () => builder.Build().LoggerName.ShouldEqual(CallerFileNameWithoutExtenstion());
-    static LogBuilder builder;
-    }
+    internal class when_building_a_default_logger : with_caller_info_context
+        {
+        Establish context = () => builder = (LogBuilder)new LoggingService().Info();
+        It should_have_the_file_name = () => builder.Build().LoggerName.ShouldEqual(CallerFileNameWithoutExtenstion());
+        static LogBuilder builder;
+        }
 
-internal class when_creating_a_named_logger : with_caller_info_context
-    {
-    Establish context = () => builder = (LogBuilder) new LoggingService().Info("Roger");
-    It should_change_the_name = () => builder.Build().LoggerName.ShouldEqual("Roger");
-    static LogBuilder builder;
-    }
+    internal class when_creating_a_named_logger : with_caller_info_context
+        {
+        Establish context = () => builder = (LogBuilder)new LoggingService().Info("Roger");
+        It should_change_the_name = () => builder.Build().LoggerName.ShouldEqual("Roger");
+        static LogBuilder builder;
+        }
 
-internal class when_creating_and_building_a_named_logger : with_caller_info_context
-    {
-    Establish context = () => builder = (LogBuilder) new LoggingService().Info("Roger");
-    Because of = () => builder.LoggerName("Jim");
-    It should_change_the_name = () => builder.Build().LoggerName.ShouldEqual("Jim");
-    static LogBuilder builder;
-    }
+    internal class when_creating_and_building_a_named_logger : with_caller_info_context
+        {
+        Establish context = () => builder = (LogBuilder)new LoggingService().Info("Roger");
+        Because of = () => builder.LoggerName("Jim");
+        It should_change_the_name = () => builder.Build().LoggerName.ShouldEqual("Jim");
+        static LogBuilder builder;
+        }
 
-internal class when_building_a_named_logger : with_caller_info_context
-    {
-    Establish context = () => builder = (LogBuilder) new LoggingService().Info();
-    Because of = () => builder.LoggerName("Jim");
-    It should_change_the_name = () => builder.Build().LoggerName.ShouldEqual("Jim");
-    static LogBuilder builder;
-    }
+    internal class when_building_a_named_logger : with_caller_info_context
+        {
+        Establish context = () => builder = (LogBuilder)new LoggingService().Info();
+        Because of = () => builder.LoggerName("Jim");
+        It should_change_the_name = () => builder.Build().LoggerName.ShouldEqual("Jim");
+        static LogBuilder builder;
+        }
 
-[Subject(typeof(LoggingService), "ambient properties")]
-internal class when_creating_a_logger_with_ambient_properties
-    {
-    Establish context = () => log = new LoggingService().WithAmbientProperty(PropertyName, true);
-    Because of = () => builder = log.Debug() as LogBuilder;
-    It should_add_the_ambient_properties = () => builder.Build().Properties.ContainsKey(PropertyName).ShouldBeTrue();
-    private static LogBuilder builder;
-    private static ILog log;
-    private const string PropertyName = "TestProperty";
+    [Subject(typeof(LoggingService), "ambient properties")]
+    internal class when_creating_a_logger_with_ambient_properties
+        {
+        Establish context = () => log = new LoggingService().WithAmbientProperty(PropertyName, true);
+        Because of = () => builder = log.Debug() as LogBuilder;
+        It should_add_the_ambient_properties = () => builder.Build().Properties.ContainsKey(PropertyName).ShouldBeTrue();
+        private static LogBuilder builder;
+        private static ILog log;
+        private const string PropertyName = "TestProperty";
+        }
     }

--- a/TA.Utils.Specifications/OctetSpecs.cs
+++ b/TA.Utils.Specifications/OctetSpecs.cs
@@ -95,6 +95,8 @@ namespace TA.Utils.Specifications
     [Subject(typeof(Octet), "Immutability")]
     public class when_mutating_an_octet
         {
+        // ReSharper disable once EqualExpressionComparison
+        // ReSharper disable once ConditionIsAlwaysTrueOrFalse
         It should_intern_well_known_instances = () => ReferenceEquals(Octet.Zero, Octet.Zero).ShouldBeTrue();
         It should_be_immutable = () => ReferenceEquals(immutable.WithBitSetTo(3, false), immutable).ShouldBeFalse();
         static Octet immutable = Octet.Max;

--- a/TA.Utils.Specifications/OctetSpecs.cs
+++ b/TA.Utils.Specifications/OctetSpecs.cs
@@ -2,6 +2,8 @@
 // Copyright © 2016-2020 Tigra Astronomy, all rights reserved.
 // File: OctetSpecs.cs  Last modified: 2020-07-13@02:11 by Tim Long
 
+using System;
+using System.Linq;
 using Machine.Specifications;
 using TA.Utils.Core;
 
@@ -19,22 +21,75 @@ namespace TA.Utils.Specifications
     [Subject(typeof(Octet), "Bit Manipulation")]
     public class when_manipulating_bits
         {
-        It should_set_bit_0 = () => Octet.Zero.WithBitSetTo(0, true).ShouldEqual((Octet) 0b00000001);
-        It should_set_bit_1 = () => Octet.Zero.WithBitSetTo(1, true).ShouldEqual((Octet) 0b00000010);
-        It should_set_bit_2 = () => Octet.Zero.WithBitSetTo(2, true).ShouldEqual((Octet) 0b00000100);
-        It should_set_bit_3 = () => Octet.Zero.WithBitSetTo(3, true).ShouldEqual((Octet) 0b00001000);
-        It should_set_bit_4 = () => Octet.Zero.WithBitSetTo(4, true).ShouldEqual((Octet) 0b00010000);
-        It should_set_bit_5 = () => Octet.Zero.WithBitSetTo(5, true).ShouldEqual((Octet) 0b00100000);
-        It should_set_bit_6 = () => Octet.Zero.WithBitSetTo(6, true).ShouldEqual((Octet) 0b01000000);
-        It should_set_bit_7 = () => Octet.Zero.WithBitSetTo(7, true).ShouldEqual((Octet) 0b10000000);
-        It should_clear_bit_0 = () => Octet.Max.WithBitSetTo(0, false).ShouldEqual((Octet) 0b11111110);
-        It should_clear_bit_1 = () => Octet.Max.WithBitSetTo(1, false).ShouldEqual((Octet) 0b11111101);
-        It should_clear_bit_2 = () => Octet.Max.WithBitSetTo(2, false).ShouldEqual((Octet) 0b11111011);
-        It should_clear_bit_3 = () => Octet.Max.WithBitSetTo(3, false).ShouldEqual((Octet) 0b11110111);
-        It should_clear_bit_4 = () => Octet.Max.WithBitSetTo(4, false).ShouldEqual((Octet) 0b11101111);
-        It should_clear_bit_5 = () => Octet.Max.WithBitSetTo(5, false).ShouldEqual((Octet) 0b11011111);
-        It should_clear_bit_6 = () => Octet.Max.WithBitSetTo(6, false).ShouldEqual((Octet) 0b10111111);
-        It should_clear_bit_7 = () => Octet.Max.WithBitSetTo(7, false).ShouldEqual((Octet) 0b01111111);
+        It should_set_bit_0 = () => Octet.Zero.WithBitSet(0).ShouldEqual((Octet) 0b00000001);
+        It should_set_bit_1 = () => Octet.Zero.WithBitSet(1).ShouldEqual((Octet) 0b00000010);
+        It should_set_bit_2 = () => Octet.Zero.WithBitSet(2).ShouldEqual((Octet) 0b00000100);
+        It should_set_bit_3 = () => Octet.Zero.WithBitSet(3).ShouldEqual((Octet) 0b00001000);
+        It should_set_bit_4 = () => Octet.Zero.WithBitSet(4).ShouldEqual((Octet) 0b00010000);
+        It should_set_bit_5 = () => Octet.Zero.WithBitSet(5).ShouldEqual((Octet) 0b00100000);
+        It should_set_bit_6 = () => Octet.Zero.WithBitSet(6).ShouldEqual((Octet) 0b01000000);
+        It should_set_bit_7 = () => Octet.Zero.WithBitSet(7).ShouldEqual((Octet) 0b10000000);
+        It should_clear_bit_0 = () => Octet.Max.WithBitClear(0).ShouldEqual((Octet) 0b11111110);
+        It should_clear_bit_1 = () => Octet.Max.WithBitClear(1).ShouldEqual((Octet) 0b11111101);
+        It should_clear_bit_2 = () => Octet.Max.WithBitClear(2).ShouldEqual((Octet) 0b11111011);
+        It should_clear_bit_3 = () => Octet.Max.WithBitClear(3).ShouldEqual((Octet) 0b11110111);
+        It should_clear_bit_4 = () => Octet.Max.WithBitClear(4).ShouldEqual((Octet) 0b11101111);
+        It should_clear_bit_5 = () => Octet.Max.WithBitClear(5).ShouldEqual((Octet) 0b11011111);
+        It should_clear_bit_6 = () => Octet.Max.WithBitClear(6).ShouldEqual((Octet) 0b10111111);
+        It should_clear_bit_7 = () => Octet.Max.WithBitClear(7).ShouldEqual((Octet) 0b01111111);
+        }
+
+    [Subject(typeof(Octet), "Bit setting")]
+    public class when_setting_a_bit_in_an_octet
+        {
+        Establish context = () => octet = Octet.Zero;
+        Because of = () => result = Octet.Zero.WithBitSet(3);
+        It should_return_a_new_octet = () => result.ShouldNotEqual(octet);
+        It should_set_the_specified_bit_to_one = () => result[bitNumber].ShouldBeTrue();
+        It should_not_change_other_bits = () =>
+            {
+            for (int i = 0; i < 8; i++)
+                {
+                if (i != bitNumber)
+                    result[i].ShouldEqual(octet[i]);
+                }
+            };
+        static Octet octet;
+        const int bitNumber = 3;
+        static Octet result;
+        }
+
+    [Subject(typeof(Octet), "Bit setting, invalid bit number")]
+    public class when_setting_a_bit_outside_the_valid_range
+        {
+        Because of = () => exception = Catch.Exception(() => Octet.Zero.WithBitSet(8));
+        It should_throw_an_argument_out_of_range_exception = () => exception.ShouldBeOfExactType<ArgumentOutOfRangeException>();
+        static Exception exception;
+        }
+
+    [Subject(typeof(Octet), "Bit clearing")]
+    public class when_clearing_a_bit_in_an_octet
+        {
+        Establish context = () => octet = Octet.Max;
+        Because of = () => result = octet.WithBitClear(3);
+        It should_return_a_new_octet = () => result.ShouldNotEqual(octet);
+        It should_clear_the_specified_bit_to_zero = () => result[bitNumber].ShouldBeFalse();
+        It should_not_change_other_bits = () =>
+            Enumerable.Range(0, 8)
+                .Where(i => i != bitNumber)
+                .All(i => result[i] == octet[i])
+                .ShouldBeTrue();
+        static Octet octet;
+        const int bitNumber = 3;
+        static Octet result;
+        }
+
+    [Subject(typeof(Octet), "Bit setting, invalid bit number")]
+    public class when_clearing_a_bit_outside_the_valid_range
+        {
+        Because of = () => exception = Catch.Exception(() => Octet.Zero.WithBitClear(8));
+        It should_throw_an_argument_out_of_range_exception = () => exception.ShouldBeOfExactType<ArgumentOutOfRangeException>();
+        static Exception exception;
         }
 
     [Subject(typeof(Octet), "Immutability")]

--- a/TA.Utils.Specifications/SemanticVersionSpecs.cs
+++ b/TA.Utils.Specifications/SemanticVersionSpecs.cs
@@ -35,10 +35,10 @@ namespace TA.Utils.Specifications
         It should_sort_higher_versions_second = () => v101.ShouldBeGreaterThan(v100);
         It should_sort_prerelease_versions_before_releases = () => v101pre9.ShouldBeLessThan(v101);
         It should_prefer_numeric_order_over_lexical_order = () => v101pre9.ShouldBeLessThan(v101pre10);
-        static SemanticVersion v100 = new SemanticVersion("1.0.0");
-        static SemanticVersion v101 = new SemanticVersion("1.0.1");
-        static SemanticVersion v101pre10 = new SemanticVersion("1.0.1-alpha.10");
-        static SemanticVersion v101pre9 = new SemanticVersion("1.0.1-alpha.9");
+        static readonly SemanticVersion v100 = new SemanticVersion("1.0.0");
+        static readonly SemanticVersion v101 = new SemanticVersion("1.0.1");
+        static readonly SemanticVersion v101pre10 = new SemanticVersion("1.0.1-alpha.10");
+        static readonly SemanticVersion v101pre9 = new SemanticVersion("1.0.1-alpha.9");
         }
 
     [Subject(typeof(SemanticVersion), "equality")]
@@ -47,9 +47,9 @@ namespace TA.Utils.Specifications
         It should_require_prerelease_tags_to_match = () => v100p5.ShouldNotEqual(v100p6);
         It should_ignore_missing_build_metadata = () => v100p5.Equals(v100p5b1).ShouldBeTrue();
         It should_ignore_different_build_metadata = () => v100p5b1.Equals(v100p5b2).ShouldBeTrue();
-        static SemanticVersion v100p5 = new SemanticVersion("1.0.0-prerelease.5");
-        static SemanticVersion v100p5b1 = new SemanticVersion("1.0.0-prerelease.5+build.1");
-        static SemanticVersion v100p5b2 = new SemanticVersion("1.0.0-prerelease.5+build.2");
-        static SemanticVersion v100p6 = new SemanticVersion("1.0.0-prerelease.6");
+        static readonly SemanticVersion v100p5 = new SemanticVersion("1.0.0-prerelease.5");
+        static readonly SemanticVersion v100p5b1 = new SemanticVersion("1.0.0-prerelease.5+build.1");
+        static readonly SemanticVersion v100p5b2 = new SemanticVersion("1.0.0-prerelease.5+build.2");
+        static readonly SemanticVersion v100p6 = new SemanticVersion("1.0.0-prerelease.6");
         }
     }

--- a/TA.Utils.Specifications/SemanticVersionSpecs.cs
+++ b/TA.Utils.Specifications/SemanticVersionSpecs.cs
@@ -31,14 +31,14 @@ namespace TA.Utils.Specifications
     [Subject(typeof(SemanticVersion), "sorting and comparison")]
     public class when_sorting_semantic_versions
         {
-        It should_sort_lower_versions_first = () => v100.ShouldBeLessThan(v101);
-        It should_sort_higher_versions_second = () => v101.ShouldBeGreaterThan(v100);
-        It should_sort_prerelease_versions_before_releases = () => v101pre9.ShouldBeLessThan(v101);
-        It should_prefer_numeric_order_over_lexical_order = () => v101pre9.ShouldBeLessThan(v101pre10);
-        static readonly SemanticVersion v100 = new SemanticVersion("1.0.0");
-        static readonly SemanticVersion v101 = new SemanticVersion("1.0.1");
-        static readonly SemanticVersion v101pre10 = new SemanticVersion("1.0.1-alpha.10");
-        static readonly SemanticVersion v101pre9 = new SemanticVersion("1.0.1-alpha.9");
+        It should_sort_lower_versions_first = () => V100.ShouldBeLessThan(V101);
+        It should_sort_higher_versions_second = () => V101.ShouldBeGreaterThan(V100);
+        It should_sort_prerelease_versions_before_releases = () => V101Pre9.ShouldBeLessThan(V101);
+        It should_prefer_numeric_order_over_lexical_order = () => V101Pre9.ShouldBeLessThan(V101Pre10);
+        static readonly SemanticVersion V100 = new("1.0.0");
+        static readonly SemanticVersion V101 = new("1.0.1");
+        static readonly SemanticVersion V101Pre10 = new("1.0.1-alpha.10");
+        static readonly SemanticVersion V101Pre9 = new("1.0.1-alpha.9");
         }
 
     [Subject(typeof(SemanticVersion), "equality")]
@@ -47,9 +47,9 @@ namespace TA.Utils.Specifications
         It should_require_prerelease_tags_to_match = () => v100p5.ShouldNotEqual(v100p6);
         It should_ignore_missing_build_metadata = () => v100p5.Equals(v100p5b1).ShouldBeTrue();
         It should_ignore_different_build_metadata = () => v100p5b1.Equals(v100p5b2).ShouldBeTrue();
-        static readonly SemanticVersion v100p5 = new SemanticVersion("1.0.0-prerelease.5");
-        static readonly SemanticVersion v100p5b1 = new SemanticVersion("1.0.0-prerelease.5+build.1");
-        static readonly SemanticVersion v100p5b2 = new SemanticVersion("1.0.0-prerelease.5+build.2");
-        static readonly SemanticVersion v100p6 = new SemanticVersion("1.0.0-prerelease.6");
+        static readonly SemanticVersion v100p5 = new("1.0.0-prerelease.5");
+        static readonly SemanticVersion v100p5b1 = new("1.0.0-prerelease.5+build.1");
+        static readonly SemanticVersion v100p5b2 = new("1.0.0-prerelease.5+build.2");
+        static readonly SemanticVersion v100p6 = new("1.0.0-prerelease.6");
         }
     }

--- a/TA.Utils.Specifications/StringExtensionSpecs.cs
+++ b/TA.Utils.Specifications/StringExtensionSpecs.cs
@@ -1,23 +1,138 @@
 ﻿// This file is part of the TA.Utils project
-// Copyright © 2016-2023 Tigra Astronomy, all rights reserved.
-// File: StringExtensionSpecs.cs  Last modified: 2023-07-29@13:26 by Tim Long
+// Copyright © 2016-2023 Timtek Systems Limited, all rights reserved.
+// File: StringExtensionSpecs.cs  Last modified: 2023-08-14@03:15 by Tim Long
 
+using System;
 using Machine.Specifications;
 using TA.Utils.Core;
 
 namespace TA.Utils.Specifications;
 
-[Subject(typeof(StringExtensions), "Head")]
-internal class when_taking_the_head_of_a_string
+[Subject(typeof(StringExtensions), "Cleaning")]
+public class when_cleaning_a_string
     {
-     It should_extract_the_head = () => inputString.Head(19).ShouldEqual("The quick brown fox");
-     It should_extract_the_dog_tail = () => inputString.Tail(8).ShouldEqual("lazy dog");
-     It should_keep_the_vowels = () => inputString.Keep("aeiou").ShouldEqual("euioouoeeao");
-     It should_remove_the_vowels = () => inputString.Clean("aeiou").ShouldEqual("Th qck brwn fx jmps vr th lzy dg");
-     It should_remove_the_fox_head = () => inputString.RemoveHead(20).ShouldEqual("jumps over the lazy dog");
-     It should_remove_the_lazy_dog = () => inputString.RemoveTail(9).ShouldEqual("The quick brown fox jumps over the");
-     It should_convert_ascii_to_hex = () => "123".ToHex().ShouldEqual("{31, 32, 33}");
-    //                                            1         2         3         4
-    //                                  0123456789012345678901234567890123456789012
-    private const string inputString = "The quick brown fox jumps over the lazy dog";
+    private It should_remove_unwanted_characters = () => "Hello, World!".Clean(",!").ShouldEqual("Hello World");
+    }
+
+[Subject(typeof(StringExtensions))]
+public class when_cleaning_an_empty_string
+    {
+    private It should_return_empty_string = () => string.Empty.Clean(",!").ShouldEqual(string.Empty);
+    }
+
+[Subject(typeof(StringExtensions))]
+public class when_cleaning_a_string_with_empty_clean_string
+    {
+    private It should_return_original_string = () => "Hello, World!".Clean(string.Empty).ShouldEqual("Hello, World!");
+    }
+
+[Subject(typeof(StringExtensions))]
+public class when_keeping_characters_in_a_string
+    {
+    private It should_keep_only_specified_characters = () => "Hello, World!".Keep("loWrd").ShouldEqual("lloWorld");
+    }
+
+[Subject(typeof(StringExtensions))]
+public class when_keeping_characters_in_an_empty_string
+    {
+    private It should_return_empty_string = () => string.Empty.Keep("loWrd").ShouldEqual(string.Empty);
+    }
+
+[Subject(typeof(StringExtensions))]
+public class when_keeping_characters_with_no_matching_characters
+    {
+    private It should_return_empty_string = () => "Hello, World!".Keep("xyz").ShouldEqual(string.Empty);
+    }
+
+[Subject(typeof(StringExtensions))]
+public class when_getting_tail_of_a_string
+    {
+    private It should_return_last_n_characters = () => "Hello, World!".Tail(6).ShouldEqual("World!");
+    }
+
+[Subject(typeof(StringExtensions))]
+public class when_getting_tail_with_zero_length
+    {
+    private It should_return_empty_string = () => "Hello, World!".Tail(0).ShouldEqual(string.Empty);
+    }
+
+[Subject(typeof(StringExtensions))]
+public class when_getting_tail_with_length_greater_than_string_length
+    {
+    private It should_throw_argument_out_of_range_exception = () =>
+        Catch.Exception(() => "Hello, World!".Tail(14)).ShouldBeOfExactType<ArgumentOutOfRangeException>();
+    }
+
+[Subject(typeof(StringExtensions))]
+public class when_getting_head_of_a_string
+    {
+    private It should_return_first_n_characters = () => "Hello, World!".Head(5).ShouldEqual("Hello");
+    }
+
+[Subject(typeof(StringExtensions))]
+public class when_getting_head_with_zero_length
+    {
+    private It should_return_empty_string = () => "Hello, World!".Head(0).ShouldEqual(string.Empty);
+    }
+
+[Subject(typeof(StringExtensions))]
+public class when_getting_head_with_length_greater_than_string_length
+    {
+    private It should_throw_argument_out_of_range_exception = () =>
+        Catch.Exception(() => "Hello, World!".Head(14)).ShouldBeOfExactType<ArgumentOutOfRangeException>();
+    }
+
+[Subject(typeof(StringExtensions))]
+public class when_removing_head_of_a_string
+    {
+    private It should_remove_first_n_characters = () => "Hello, World!".RemoveHead(6).ShouldEqual(" World!");
+    }
+
+[Subject(typeof(StringExtensions))]
+public class when_removing_head_with_zero_length
+    {
+    private It should_return_original_string = () => "Hello, World!".RemoveHead(0).ShouldEqual("Hello, World!");
+    }
+
+[Subject(typeof(StringExtensions))]
+public class when_removing_head_with_length_greater_than_string_length
+    {
+    private It should_return_empty_string = () => "Hello, World!".RemoveHead(13).ShouldEqual(string.Empty);
+    }
+
+[Subject(typeof(StringExtensions))]
+public class when_removing_tail_of_a_string
+    {
+    private It should_remove_last_n_characters = () => "Hello, World!".RemoveTail(6).ShouldEqual("Hello, ");
+    }
+
+[Subject(typeof(StringExtensions))]
+public class when_removing_tail_with_zero_length
+    {
+    private It should_return_original_string = () => "Hello, World!".RemoveTail(0).ShouldEqual("Hello, World!");
+    }
+
+[Subject(typeof(StringExtensions))]
+public class when_removing_tail_with_length_greater_than_string_length
+    {
+    private It should_return_empty_string = () => "Hello, World!".RemoveTail(13).ShouldEqual(string.Empty);
+    }
+
+[Subject(typeof(StringExtensions))]
+public class when_converting_string_to_hex
+    {
+    private It should_return_hex_representation = () => "Hello".ToHex().ShouldEqual("{48, 65, 6c, 6c, 6f}");
+    }
+
+[Subject(typeof(StringExtensions))]
+public class when_converting_empty_string_to_hex
+    {
+    private It should_return_empty_braces = () => "".ToHex().ShouldEqual("{}");
+    }
+
+[Subject(typeof(StringExtensions))]
+public class when_converting_null_string_to_hex
+    {
+    private It should_throw_null_reference_exception =
+        () => Catch.Exception(() => ((string)null).ToHex()).ShouldBeOfExactType<NullReferenceException>();
     }

--- a/TA.Utils.Specifications/StringExtensionSpecs.cs
+++ b/TA.Utils.Specifications/StringExtensionSpecs.cs
@@ -1,0 +1,23 @@
+﻿// This file is part of the TA.Utils project
+// Copyright © 2016-2023 Tigra Astronomy, all rights reserved.
+// File: StringExtensionSpecs.cs  Last modified: 2023-07-29@13:26 by Tim Long
+
+using Machine.Specifications;
+using TA.Utils.Core;
+
+namespace TA.Utils.Specifications;
+
+[Subject(typeof(StringExtensions), "Head")]
+internal class when_taking_the_head_of_a_string
+    {
+     It should_extract_the_head = () => inputString.Head(19).ShouldEqual("The quick brown fox");
+     It should_extract_the_dog_tail = () => inputString.Tail(8).ShouldEqual("lazy dog");
+     It should_keep_the_vowels = () => inputString.Keep("aeiou").ShouldEqual("euioouoeeao");
+     It should_remove_the_vowels = () => inputString.Clean("aeiou").ShouldEqual("Th qck brwn fx jmps vr th lzy dg");
+     It should_remove_the_fox_head = () => inputString.RemoveHead(20).ShouldEqual("jumps over the lazy dog");
+     It should_remove_the_lazy_dog = () => inputString.RemoveTail(9).ShouldEqual("The quick brown fox jumps over the");
+     It should_convert_ascii_to_hex = () => "123".ToHex().ShouldEqual("{31, 32, 33}");
+    //                                            1         2         3         4
+    //                                  0123456789012345678901234567890123456789012
+    private const string inputString = "The quick brown fox jumps over the lazy dog";
+    }

--- a/TA.Utils.Specifications/TA.Utils.Specifications.csproj
+++ b/TA.Utils.Specifications/TA.Utils.Specifications.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/TA.Utils.Specifications/TA.Utils.Specifications.csproj
+++ b/TA.Utils.Specifications/TA.Utils.Specifications.csproj
@@ -7,7 +7,7 @@
   <ItemGroup>
     <PackageReference Include="Machine.Specifications.Should" Version="1.0.0" />
     <PackageReference Include="Machine.Specifications.Runner.VisualStudio" Version="2.10.1" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.6.1" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.7.0" />
     <PackageReference Include="NLog" Version="4.7.2" />
   </ItemGroup>
 

--- a/TA.Utils.Specifications/TA.Utils.Specifications.csproj.DotSettings
+++ b/TA.Utils.Specifications/TA.Utils.Specifications.csproj.DotSettings
@@ -8,7 +8,30 @@
 	<s:Int64 x:Key="/Default/CodeStyle/CodeFormatting/CSharpFormat/WRAP_LIMIT/@EntryValue">140</s:Int64>
 	<s:String x:Key="/Default/CodeStyle/CSharpFileLayoutPatterns/Pattern/@EntryValue">&lt;?xml version="1.0" encoding="utf-16"?&gt;&#xD;
 &lt;Patterns xmlns="urn:schemas-jetbrains-com:member-reordering-patterns"&gt;&#xD;
-  &lt;TypePattern DisplayName="Machine.Specifications" Priority="100"&gt;&#xD;
+  &lt;FilePattern RemoveRegions="AllExceptGenerated"&gt;&#xD;
+    &lt;Region Name=" Context base classes"&gt;&#xD;
+      &lt;Entry DisplayName="with_"&gt;&#xD;
+        &lt;Entry.Match&gt;&#xD;
+          &lt;And&gt;&#xD;
+            &lt;Kind Is="Class" /&gt;&#xD;
+            &lt;Name Is="^with_.+$" IgnoreCase="True" /&gt;&#xD;
+          &lt;/And&gt;&#xD;
+        &lt;/Entry.Match&gt;&#xD;
+      &lt;/Entry&gt;&#xD;
+    &lt;/Region&gt;&#xD;
+    &lt;Entry DisplayName="when_"&gt;&#xD;
+      &lt;Entry.Match&gt;&#xD;
+        &lt;And&gt;&#xD;
+          &lt;Kind Is="Class" /&gt;&#xD;
+          &lt;Or&gt;&#xD;
+            &lt;HasAttribute Name="^Subject$" /&gt;&#xD;
+            &lt;Name Is="^when_.+$" IgnoreCase="True" /&gt;&#xD;
+          &lt;/Or&gt;&#xD;
+        &lt;/And&gt;&#xD;
+      &lt;/Entry.Match&gt;&#xD;
+    &lt;/Entry&gt;&#xD;
+  &lt;/FilePattern&gt;&#xD;
+  &lt;TypePattern DisplayName="Machine.Specifications"&gt;&#xD;
     &lt;TypePattern.Match&gt;&#xD;
       &lt;And&gt;&#xD;
         &lt;Kind Is="Class" /&gt;&#xD;
@@ -77,29 +100,6 @@
       &lt;/Entry.Match&gt;&#xD;
     &lt;/Entry&gt;&#xD;
   &lt;/TypePattern&gt;&#xD;
-  &lt;FilePattern RemoveRegions="AllExceptGenerated"&gt;&#xD;
-    &lt;Region Name=" Context base classes"&gt;&#xD;
-      &lt;Entry DisplayName="with_"&gt;&#xD;
-        &lt;Entry.Match&gt;&#xD;
-          &lt;And&gt;&#xD;
-            &lt;Kind Is="Class" /&gt;&#xD;
-            &lt;Name Is="^with_.+$" IgnoreCase="True" /&gt;&#xD;
-          &lt;/And&gt;&#xD;
-        &lt;/Entry.Match&gt;&#xD;
-      &lt;/Entry&gt;&#xD;
-    &lt;/Region&gt;&#xD;
-    &lt;Entry DisplayName="when_"&gt;&#xD;
-      &lt;Entry.Match&gt;&#xD;
-        &lt;And&gt;&#xD;
-          &lt;Kind Is="Class" /&gt;&#xD;
-          &lt;Or&gt;&#xD;
-            &lt;HasAttribute Name="^Subject$" /&gt;&#xD;
-            &lt;Name Is="^when_.+$" IgnoreCase="True" /&gt;&#xD;
-          &lt;/Or&gt;&#xD;
-        &lt;/And&gt;&#xD;
-      &lt;/Entry.Match&gt;&#xD;
-    &lt;/Entry&gt;&#xD;
-  &lt;/FilePattern&gt;&#xD;
 &lt;/Patterns&gt;</s:String>
 	<s:String x:Key="/Default/CodeStyle/Naming/CSharpNaming/PredefinedNamingRules/=PrivateInstanceFields/@EntryIndexedValue">&lt;Policy Inspect="True" Prefix="" Suffix="" Style="aaBb"&gt;&lt;ExtraRule Prefix="should_" Suffix="" Style="aaBb" /&gt;&lt;ExtraRule Prefix="of" Suffix="" Style="aa_bb" /&gt;&lt;ExtraRule Prefix="context" Suffix="" Style="aa_bb" /&gt;&lt;ExtraRule Prefix="after" Suffix="" Style="aa_bb" /&gt;&lt;/Policy&gt;</s:String>
 	<s:String x:Key="/Default/CodeStyle/Naming/CSharpNaming/PredefinedNamingRules/=PrivateStaticFields/@EntryIndexedValue">&lt;Policy Inspect="True" Prefix="" Suffix="" Style="aaBb" /&gt;</s:String>

--- a/TA.Utils.Specifications/TA.Utils.Specifications.csproj.DotSettings
+++ b/TA.Utils.Specifications/TA.Utils.Specifications.csproj.DotSettings
@@ -1,32 +1,14 @@
 ﻿<wpf:ResourceDictionary xml:space="preserve" xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml" xmlns:s="clr-namespace:System;assembly=mscorlib" xmlns:ss="urn:shemas-jetbrains-com:settings-storage-xaml" xmlns:wpf="http://schemas.microsoft.com/winfx/2006/xaml/presentation">
+	<s:String x:Key="/Default/CodeInspection/Highlighting/InspectionSeverities/=ArrangeTypeMemberModifiers/@EntryIndexedValue">SUGGESTION</s:String>
+	<s:String x:Key="/Default/CodeInspection/Highlighting/InspectionSeverities/=ArrangeTypeModifiers/@EntryIndexedValue">SUGGESTION</s:String>
+	<s:String x:Key="/Default/CodeStyle/CodeCleanup/Profiles/=MSpec/@EntryIndexedValue">&lt;?xml version="1.0" encoding="utf-16"?&gt;&lt;Profile name="MSpec"&gt;&lt;CSCodeStyleAttributes ArrangeVarStyle="True" ArrangeTypeAccessModifier="True" ArrangeTypeMemberAccessModifier="True" SortModifiers="True" ArrangeArgumentsStyle="True" RemoveRedundantParentheses="True" AddMissingParentheses="True" ArrangeBraces="True" ArrangeAttributes="True" ArrangeCodeBodyStyle="True" ArrangeTrailingCommas="True" ArrangeObjectCreation="True" ArrangeDefaultValue="True" ArrangeNamespaces="True" ArrangeNullCheckingPattern="True" /&gt;&lt;Xaml.RedundantFreezeAttribute&gt;True&lt;/Xaml.RedundantFreezeAttribute&gt;&lt;Xaml.RemoveRedundantModifiersAttribute&gt;True&lt;/Xaml.RemoveRedundantModifiersAttribute&gt;&lt;Xaml.RemoveRedundantNameAttribute&gt;True&lt;/Xaml.RemoveRedundantNameAttribute&gt;&lt;Xaml.RemoveRedundantResource&gt;True&lt;/Xaml.RemoveRedundantResource&gt;&lt;Xaml.RemoveRedundantCollectionProperty&gt;True&lt;/Xaml.RemoveRedundantCollectionProperty&gt;&lt;Xaml.RemoveRedundantAttachedPropertySetter&gt;True&lt;/Xaml.RemoveRedundantAttachedPropertySetter&gt;&lt;Xaml.RemoveRedundantStyledValue&gt;True&lt;/Xaml.RemoveRedundantStyledValue&gt;&lt;Xaml.RemoveRedundantNamespaceAlias&gt;True&lt;/Xaml.RemoveRedundantNamespaceAlias&gt;&lt;Xaml.RemoveForbiddenResourceName&gt;True&lt;/Xaml.RemoveForbiddenResourceName&gt;&lt;Xaml.RemoveRedundantGridDefinitionsAttribute&gt;True&lt;/Xaml.RemoveRedundantGridDefinitionsAttribute&gt;&lt;Xaml.RemoveRedundantUpdateSourceTriggerAttribute&gt;True&lt;/Xaml.RemoveRedundantUpdateSourceTriggerAttribute&gt;&lt;Xaml.RemoveRedundantBindingModeAttribute&gt;True&lt;/Xaml.RemoveRedundantBindingModeAttribute&gt;&lt;Xaml.RemoveRedundantGridSpanAttribut&gt;True&lt;/Xaml.RemoveRedundantGridSpanAttribut&gt;&lt;XMLReformatCode&gt;True&lt;/XMLReformatCode&gt;&lt;CSArrangeQualifiers&gt;True&lt;/CSArrangeQualifiers&gt;&lt;CSFixBuiltinTypeReferences&gt;True&lt;/CSFixBuiltinTypeReferences&gt;&lt;HtmlReformatCode&gt;True&lt;/HtmlReformatCode&gt;&lt;VBReformatCode&gt;True&lt;/VBReformatCode&gt;&lt;CSReformatCode&gt;True&lt;/CSReformatCode&gt;&lt;FormatAttributeQuoteDescriptor&gt;True&lt;/FormatAttributeQuoteDescriptor&gt;&lt;/Profile&gt;</s:String>
+	<s:Boolean x:Key="/Default/CodeStyle/CodeFormatting/CSharpCodeStyle/APPLY_ON_COMPLETION/@EntryValue">True</s:Boolean>
 	<s:String x:Key="/Default/CodeStyle/CodeFormatting/CSharpCodeStyle/DEFAULT_INTERNAL_MODIFIER/@EntryValue">Implicit</s:String>
 	<s:String x:Key="/Default/CodeStyle/CodeFormatting/CSharpCodeStyle/DEFAULT_PRIVATE_MODIFIER/@EntryValue">Implicit</s:String>
+	<s:Int64 x:Key="/Default/CodeStyle/CodeFormatting/CSharpFormat/WRAP_LIMIT/@EntryValue">140</s:Int64>
 	<s:String x:Key="/Default/CodeStyle/CSharpFileLayoutPatterns/Pattern/@EntryValue">&lt;?xml version="1.0" encoding="utf-16"?&gt;&#xD;
 &lt;Patterns xmlns="urn:schemas-jetbrains-com:member-reordering-patterns"&gt;&#xD;
-  &lt;FilePattern RemoveRegions="AllExceptGenerated"&gt;&#xD;
-    &lt;Region Name=" Context base classes"&gt;&#xD;
-      &lt;Entry DisplayName="with_"&gt;&#xD;
-        &lt;Entry.Match&gt;&#xD;
-          &lt;And&gt;&#xD;
-            &lt;Kind Is="Class" /&gt;&#xD;
-            &lt;Name Is="^with_.+$" IgnoreCase="True" /&gt;&#xD;
-          &lt;/And&gt;&#xD;
-        &lt;/Entry.Match&gt;&#xD;
-      &lt;/Entry&gt;&#xD;
-    &lt;/Region&gt;&#xD;
-    &lt;Entry DisplayName="when_"&gt;&#xD;
-      &lt;Entry.Match&gt;&#xD;
-        &lt;And&gt;&#xD;
-          &lt;Kind Is="Class" /&gt;&#xD;
-          &lt;Or&gt;&#xD;
-            &lt;HasAttribute Name="^Subject$" /&gt;&#xD;
-            &lt;Name Is="^when_.+$" IgnoreCase="True" /&gt;&#xD;
-          &lt;/Or&gt;&#xD;
-        &lt;/And&gt;&#xD;
-      &lt;/Entry.Match&gt;&#xD;
-    &lt;/Entry&gt;&#xD;
-  &lt;/FilePattern&gt;&#xD;
-  &lt;TypePattern DisplayName="Machine.Specifications"&gt;&#xD;
+  &lt;TypePattern DisplayName="Machine.Specifications" Priority="100"&gt;&#xD;
     &lt;TypePattern.Match&gt;&#xD;
       &lt;And&gt;&#xD;
         &lt;Kind Is="Class" /&gt;&#xD;
@@ -95,12 +77,42 @@
       &lt;/Entry.Match&gt;&#xD;
     &lt;/Entry&gt;&#xD;
   &lt;/TypePattern&gt;&#xD;
+  &lt;FilePattern RemoveRegions="AllExceptGenerated"&gt;&#xD;
+    &lt;Region Name=" Context base classes"&gt;&#xD;
+      &lt;Entry DisplayName="with_"&gt;&#xD;
+        &lt;Entry.Match&gt;&#xD;
+          &lt;And&gt;&#xD;
+            &lt;Kind Is="Class" /&gt;&#xD;
+            &lt;Name Is="^with_.+$" IgnoreCase="True" /&gt;&#xD;
+          &lt;/And&gt;&#xD;
+        &lt;/Entry.Match&gt;&#xD;
+      &lt;/Entry&gt;&#xD;
+    &lt;/Region&gt;&#xD;
+    &lt;Entry DisplayName="when_"&gt;&#xD;
+      &lt;Entry.Match&gt;&#xD;
+        &lt;And&gt;&#xD;
+          &lt;Kind Is="Class" /&gt;&#xD;
+          &lt;Or&gt;&#xD;
+            &lt;HasAttribute Name="^Subject$" /&gt;&#xD;
+            &lt;Name Is="^when_.+$" IgnoreCase="True" /&gt;&#xD;
+          &lt;/Or&gt;&#xD;
+        &lt;/And&gt;&#xD;
+      &lt;/Entry.Match&gt;&#xD;
+    &lt;/Entry&gt;&#xD;
+  &lt;/FilePattern&gt;&#xD;
 &lt;/Patterns&gt;</s:String>
+	<s:String x:Key="/Default/CodeStyle/Naming/CSharpNaming/PredefinedNamingRules/=PrivateInstanceFields/@EntryIndexedValue">&lt;Policy Inspect="True" Prefix="" Suffix="" Style="aaBb"&gt;&lt;ExtraRule Prefix="should_" Suffix="" Style="aaBb" /&gt;&lt;ExtraRule Prefix="of" Suffix="" Style="aa_bb" /&gt;&lt;ExtraRule Prefix="context" Suffix="" Style="aa_bb" /&gt;&lt;ExtraRule Prefix="after" Suffix="" Style="aa_bb" /&gt;&lt;/Policy&gt;</s:String>
+	<s:String x:Key="/Default/CodeStyle/Naming/CSharpNaming/PredefinedNamingRules/=PrivateStaticFields/@EntryIndexedValue">&lt;Policy Inspect="True" Prefix="" Suffix="" Style="aaBb" /&gt;</s:String>
+	<s:String x:Key="/Default/CodeStyle/Naming/CSharpNaming/PredefinedNamingRules/=PublicFields/@EntryIndexedValue">&lt;Policy Inspect="True" Prefix="" Suffix="" Style="aaBb" /&gt;</s:String>
 	<s:String x:Key="/Default/CodeStyle/Naming/CSharpNaming/UserRules/=67bf0822_002D916e_002D4a66_002Db663_002D95bd84b868ab/@EntryIndexedValue">&lt;Policy&gt;&lt;Descriptor Staticness="Static, Instance" AccessRightKinds="Private, Protected, ProtectedInternal, Internal, Public" Description="MSpec context base class"&gt;&lt;ElementKinds /&gt;&lt;/Descriptor&gt;&lt;Policy Inspect="True" Prefix="with_" Suffix="" Style="aa_bb" /&gt;&lt;/Policy&gt;</s:String>
 	<s:String x:Key="/Default/CodeStyle/Naming/CSharpNaming/UserRules/=7d6f1b7c_002Dd069_002D4e79_002Da2be_002D5bbb7728b0f3/@EntryIndexedValue">&lt;Policy&gt;&lt;Descriptor Staticness="Static, Instance" AccessRightKinds="Private, Protected, ProtectedInternal, Internal, Public" Description="MSpec context class"&gt;&lt;ElementKinds /&gt;&lt;/Descriptor&gt;&lt;Policy Inspect="True" Prefix="when_" Suffix="" Style="aa_bb" /&gt;&lt;/Policy&gt;</s:String>
 	<s:String x:Key="/Default/CodeStyle/Naming/CSharpNaming/UserRules/=b094fb47_002D3d7f_002D4cbb_002Da2f8_002Dbb28913b092b/@EntryIndexedValue">&lt;Policy&gt;&lt;Descriptor Staticness="Static, Instance" AccessRightKinds="Private, Protected, ProtectedInternal, Internal, Public" Description="MSpec supporting field"&gt;&lt;ElementKinds /&gt;&lt;/Descriptor&gt;&lt;Policy Inspect="True" Prefix="" Suffix="" Style="aa_bb" /&gt;&lt;/Policy&gt;</s:String>
 	<s:String x:Key="/Default/CodeStyle/Naming/CSharpNaming/UserRules/=c0f315a1_002Dc5b2_002D4db8_002D9344_002Da923f7ccc2ff/@EntryIndexedValue">&lt;Policy&gt;&lt;Descriptor Staticness="Static, Instance" AccessRightKinds="Private, Protected, ProtectedInternal, Internal, Public" Description="MSpec specification"&gt;&lt;ElementKinds /&gt;&lt;/Descriptor&gt;&lt;Policy Inspect="True" Prefix="should_" Suffix="" Style="aa_bb" /&gt;&lt;/Policy&gt;</s:String>
+	<s:Boolean x:Key="/Default/Environment/SettingsMigration/IsMigratorApplied/=JetBrains_002EReSharper_002EPsi_002ECSharp_002ECodeStyle_002ECSharpKeepExistingMigration/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/Environment/SettingsMigration/IsMigratorApplied/=JetBrains_002EReSharper_002EPsi_002ECSharp_002ECodeStyle_002ECSharpPlaceEmbeddedOnSameLineMigration/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/Environment/SettingsMigration/IsMigratorApplied/=JetBrains_002EReSharper_002EPsi_002ECSharp_002ECodeStyle_002ECSharpUseContinuousIndentInsideBracesMigration/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/Environment/SettingsMigration/IsMigratorApplied/=JetBrains_002EReSharper_002EPsi_002ECSharp_002ECodeStyle_002ESettingsUpgrade_002EAlwaysTreatStructAsNotReorderableMigration/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/Environment/SettingsMigration/IsMigratorApplied/=JetBrains_002EReSharper_002EPsi_002ECSharp_002ECodeStyle_002ESettingsUpgrade_002EMigrateBlankLinesAroundFieldToBlankLinesAroundProperty/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/PatternsAndTemplates/LiveTemplates/Template/=06CE2469161FAF45AE8B95047F0C0630/@KeyIndexDefined">True</s:Boolean>
 	<s:Boolean x:Key="/Default/PatternsAndTemplates/LiveTemplates/Template/=06CE2469161FAF45AE8B95047F0C0630/Applicability/=Live/@EntryIndexedValue">True</s:Boolean>
 	<s:String x:Key="/Default/PatternsAndTemplates/LiveTemplates/Template/=06CE2469161FAF45AE8B95047F0C0630/Categories/=Imported_002019_002F05_002F2016/@EntryIndexedValue">Imported 19/05/2016</s:String>

--- a/TA.Utils.sln
+++ b/TA.Utils.sln
@@ -1,7 +1,7 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio Version 16
-VisualStudioVersion = 16.0.30128.36
+# Visual Studio Version 17
+VisualStudioVersion = 17.8.34004.107
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "TA.Utils.Core", "TA.Utils.Core\TA.Utils.Core.csproj", "{4D49A7E7-DC29-4292-8D19-0B2F9D24BDE6}"
 EndProject
@@ -23,7 +23,7 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Documentation", "Documentat
 		ReadMe.md = ReadMe.md
 	EndProjectSection
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "TA.Utils.Logging.NLog.SampleConsoleApp", "TA.Utils.Logging.NLog.SampleConsoleApp\TA.Utils.Logging.NLog.SampleConsoleApp.csproj", "{48B93DCE-0944-4A34-BF42-B7B5AF0DFAA0}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "TA.Utils.Logging.NLog.SampleConsoleApp", "TA.Utils.Logging.NLog.SampleConsoleApp\TA.Utils.Logging.NLog.SampleConsoleApp.csproj", "{48B93DCE-0944-4A34-BF42-B7B5AF0DFAA0}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution

--- a/TA.Utils.sln
+++ b/TA.Utils.sln
@@ -25,6 +25,8 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Documentation", "Documentat
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "TA.Utils.Logging.NLog.SampleConsoleApp", "TA.Utils.Logging.NLog.SampleConsoleApp\TA.Utils.Logging.NLog.SampleConsoleApp.csproj", "{48B93DCE-0944-4A34-BF42-B7B5AF0DFAA0}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "TA.Utils.Benchmarks", "TA.Utils.Benchmarks\TA.Utils.Benchmarks.csproj", "{8C4CF2BE-301A-4471-A574-846BFE537844}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -47,6 +49,10 @@ Global
 		{48B93DCE-0944-4A34-BF42-B7B5AF0DFAA0}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{48B93DCE-0944-4A34-BF42-B7B5AF0DFAA0}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{48B93DCE-0944-4A34-BF42-B7B5AF0DFAA0}.Release|Any CPU.Build.0 = Release|Any CPU
+		{8C4CF2BE-301A-4471-A574-846BFE537844}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{8C4CF2BE-301A-4471-A574-846BFE537844}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{8C4CF2BE-301A-4471-A574-846BFE537844}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{8C4CF2BE-301A-4471-A574-846BFE537844}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/TA.Utils.sln.DotSettings
+++ b/TA.Utils.sln.DotSettings
@@ -8,5 +8,6 @@ File: $FILENAME$  Last modified: $CURRENT_YEAR$-$CURRENT_MONTH$-$CURRENT_DAY$@$C
 	<s:Boolean x:Key="/Default/Environment/InjectedLayers/FileInjectedLayer/=C416A94FC578474BAE38CF2376C5BEA9/@KeyIndexDefined">True</s:Boolean>
 	<s:Boolean x:Key="/Default/Environment/InjectedLayers/InjectedLayerCustomization/=FileC416A94FC578474BAE38CF2376C5BEA9/@KeyIndexDefined">True</s:Boolean>
 	<s:Boolean x:Key="/Default/Environment/InjectedLayers/InjectedLayerCustomization/=FileC416A94FC578474BAE38CF2376C5BEA9/IsOn/@EntryValue">False</s:Boolean>
+	
 	<s:Double x:Key="/Default/Environment/InjectedLayers/InjectedLayerCustomization/=FileC416A94FC578474BAE38CF2376C5BEA9/RelativePriority/@EntryValue">1</s:Double>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=versioning/@EntryIndexedValue">True</s:Boolean></wpf:ResourceDictionary>

--- a/TA.Utils.sln.DotSettings
+++ b/TA.Utils.sln.DotSettings
@@ -2,6 +2,7 @@
 	<s:String x:Key="/Default/CodeStyle/FileHeader/FileHeaderText/@EntryValue">This file is part of the $SOLUTION$ project&#xD;
 Copyright © 2016-$CURRENT_YEAR$ Tigra Astronomy, all rights reserved.&#xD;
 File: $FILENAME$  Last modified: $CURRENT_YEAR$-$CURRENT_MONTH$-$CURRENT_DAY$@$CURRENT_TIME$ by $USER_NAME$</s:String>
+	<s:String x:Key="/Default/CodeStyle/Naming/CSharpNaming/PredefinedNamingRules/=PrivateStaticFields/@EntryIndexedValue">&lt;Policy Inspect="True" Prefix="" Suffix="" Style="aaBb" /&gt;</s:String>
 	<s:String x:Key="/Default/Environment/InjectedLayers/FileInjectedLayer/=C416A94FC578474BAE38CF2376C5BEA9/AbsolutePath/@EntryValue">C:\Users\Tim\source\repos\TA.Utils\TA.Utils.Specifications\TA.Utils.Specifications.csproj.DotSettings</s:String>
 	<s:String x:Key="/Default/Environment/InjectedLayers/FileInjectedLayer/=C416A94FC578474BAE38CF2376C5BEA9/RelativePath/@EntryValue">..\TA.Utils.Specifications\TA.Utils.Specifications.csproj.DotSettings</s:String>
 	<s:Boolean x:Key="/Default/Environment/InjectedLayers/FileInjectedLayer/=C416A94FC578474BAE38CF2376C5BEA9/@KeyIndexDefined">True</s:Boolean>

--- a/TA.Utils.sln.DotSettings
+++ b/TA.Utils.sln.DotSettings
@@ -1,6 +1,6 @@
 ﻿<wpf:ResourceDictionary xml:space="preserve" xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml" xmlns:s="clr-namespace:System;assembly=mscorlib" xmlns:ss="urn:shemas-jetbrains-com:settings-storage-xaml" xmlns:wpf="http://schemas.microsoft.com/winfx/2006/xaml/presentation">
 	<s:String x:Key="/Default/CodeStyle/FileHeader/FileHeaderText/@EntryValue">This file is part of the $SOLUTION$ project&#xD;
-Copyright © 2016-$CURRENT_YEAR$ Tigra Astronomy, all rights reserved.&#xD;
+Copyright © 2016-$CURRENT_YEAR$ Timtek Systems Limited, all rights reserved.&#xD;
 File: $FILENAME$  Last modified: $CURRENT_YEAR$-$CURRENT_MONTH$-$CURRENT_DAY$@$CURRENT_TIME$ by $USER_NAME$</s:String>
 	<s:String x:Key="/Default/CodeStyle/Naming/CSharpNaming/PredefinedNamingRules/=PrivateStaticFields/@EntryIndexedValue">&lt;Policy Inspect="True" Prefix="" Suffix="" Style="aaBb" /&gt;</s:String>
 	<s:String x:Key="/Default/Environment/InjectedLayers/FileInjectedLayer/=C416A94FC578474BAE38CF2376C5BEA9/AbsolutePath/@EntryValue">C:\Users\Tim\source\repos\TA.Utils\TA.Utils.Specifications\TA.Utils.Specifications.csproj.DotSettings</s:String>

--- a/TA.Utils.v3.ncrunchsolution
+++ b/TA.Utils.v3.ncrunchsolution
@@ -4,6 +4,11 @@
     <CustomBuildProperties>
       <Value>DisableGitVersionTask = true</Value>
     </CustomBuildProperties>
+    <MetricsExclusionList>
+      <Value>TA.Utils.Benchmarks\TA.Utils.Benchmarks.csproj</Value>
+      <Value>TA.Utils.Logging.NLog.SampleConsoleApp\TA.Utils.Logging.NLog.SampleConsoleApp.csproj</Value>
+      <Value>TA.Utils.Specifications\TA.Utils.Specifications.csproj</Value>
+    </MetricsExclusionList>
     <SolutionConfigured>True</SolutionConfigured>
   </Settings>
 </SolutionConfiguration>

--- a/TA.Utils.v3.ncrunchsolution
+++ b/TA.Utils.v3.ncrunchsolution
@@ -1,6 +1,9 @@
 ﻿<SolutionConfiguration>
   <Settings>
     <AllowParallelTestExecution>True</AllowParallelTestExecution>
+    <CustomBuildProperties>
+      <Value>DisableGitVersionTask = true</Value>
+    </CustomBuildProperties>
     <SolutionConfigured>True</SolutionConfigured>
   </Settings>
 </SolutionConfiguration>


### PR DESCRIPTION
GitVersion static methods now return safe defaults if the semantic version could not be determined.
Fall back to using `GetExecutingAssembly` for `GitVersion` if `GetEntryAssembly` doesn't work (fixes #2)
Added some string extension methods (`Head`, `Tail`, `ExpandAscii`, etc.) (PR#3)
Added a `WithName()` member to the ILog interface to allow the logger name to be explicitly set (useful in DI scenarios).
The above interface change is technically a breaking change as logging implementations will need to be updated, hence the major version increment.