### PR TITLE
Logging Verbosity

### DIFF
--- a/TA.Utils.Core/Diagnostics/DegenerateLoggerService.cs
+++ b/TA.Utils.Core/Diagnostics/DegenerateLoggerService.cs
@@ -19,23 +19,42 @@ namespace TA.Utils.Core.Diagnostics
     public sealed class DegenerateLoggerService : ILog
     {
         private static readonly IFluentLogBuilder builder = new DegenerateLogBuilder();
-        /// <inheritdoc />
-        public IFluentLogBuilder Trace(string callerFilePath = null) => builder;
 
         /// <inheritdoc />
-        public IFluentLogBuilder Debug(string callerFilePath = null) => builder;
+        public IFluentLogBuilder Trace(int verbosity = 0, string sourceNameOverride = null)
+        {
+            return builder;
+        }
 
         /// <inheritdoc />
-        public IFluentLogBuilder Info(string callerFilePath = null) => builder;
+        public IFluentLogBuilder Debug(int verbosity = 0, string sourceNameOverride = null)
+        {
+            return builder;
+        }
 
         /// <inheritdoc />
-        public IFluentLogBuilder Warn(string callerFilePath = null) => builder;
+        public IFluentLogBuilder Info(int verbosity = 0, string sourceNameOverride = null)
+        {
+            return builder;
+        }
 
         /// <inheritdoc />
-        public IFluentLogBuilder Error(string callerFilePath = null) => builder;
+        public IFluentLogBuilder Warn(int verbosity = 0, string sourceNameOverride = null)
+        {
+            return builder;
+        }
 
         /// <inheritdoc />
-        public IFluentLogBuilder Fatal(string callerFilePath = null) => builder;
+        public IFluentLogBuilder Error(int verbosity = 0, string sourceNameOverride = null)
+        {
+            return builder;
+        }
+
+        /// <inheritdoc />
+        public IFluentLogBuilder Fatal(int verbosity = 0, string sourceNameOverride = null)
+        {
+            return builder;
+        }
 
         /// <inheritdoc />
         public void Shutdown() { }

--- a/TA.Utils.Core/Diagnostics/IFluentLogBuilder.cs
+++ b/TA.Utils.Core/Diagnostics/IFluentLogBuilder.cs
@@ -1,14 +1,13 @@
-﻿// This file is part of the TA.Ascom.ReactiveCommunications project
-//
-// Copyright © 2015-2020 Tigra Astronomy, all rights reserved.
-//
+﻿// This file is part of the TA.Utils project
+// Copyright © 2015-2023 Timtek Systems Limited, all rights reserved.
+// 
 // Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated
 // documentation files (the "Software"), to deal in the Software without restriction, including without limitation
 // the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to
 // permit persons to whom the Software is furnished to do so. The Software comes with no warranty of any kind.
 // You make use of the Software entirely at your own risk and assume all liability arising from your use thereof.
-//
-// File: IFluentLogBuilder.cs  Last modified: 2020-07-14@07:01 by Tim Long
+// 
+// File: IFluentLogBuilder.cs  Last modified: 2023-09-01@08:38 by Tim Long
 
 using System;
 using System.Collections.Generic;
@@ -17,12 +16,12 @@ using System.Runtime.CompilerServices;
 using JetBrains.Annotations;
 
 namespace TA.Utils.Core.Diagnostics
-    {
+{
     /// <summary>
-    ///     Fluent Log Builder
+    ///     Fluent Log Builder, loosely based on the NLog fluent API, which is simple but effective.
     /// </summary>
     public interface IFluentLogBuilder
-        {
+    {
         /// <summary>
         ///     Add an exception to the log entry.
         /// </summary>
@@ -93,5 +92,5 @@ namespace TA.Utils.Core.Diagnostics
         /// </summary>
         void WriteIf(bool condition, [CallerMemberName] string callerMemberName = null,
             [CallerFilePath] string callerFilePath = null, [CallerLineNumber] int callerLineNumber = default);
-        }
     }
+}

--- a/TA.Utils.Core/Diagnostics/ILog.cs
+++ b/TA.Utils.Core/Diagnostics/ILog.cs
@@ -1,46 +1,56 @@
-﻿using System.Runtime.CompilerServices;
+﻿// This file is part of the TA.Utils project
+// Copyright © 2015-2023 Timtek Systems Limited, all rights reserved.
+// 
+// Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated
+// documentation files (the "Software"), to deal in the Software without restriction, including without limitation
+// the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to
+// permit persons to whom the Software is furnished to do so. The Software comes with no warranty of any kind.
+// You make use of the Software entirely at your own risk and assume all liability arising from your use thereof.
+// 
+// File: ILog.cs  Last modified: 2023-09-01@11:13 by Tim Long
 
 namespace TA.Utils.Core.Diagnostics
-    {
+{
     /// <summary>
-    ///     Logging service interface
+    ///     Abstract logging service interface.
     /// </summary>
     public interface ILog
-        {
+    {
         /// <summary>
         ///     Creates a log builder for a log entry with Trace severity.
         /// </summary>
-        /// <param name="callerFilePath">The caller file path.</param>
+        /// <param name="verbosity"></param>
+        /// <param name="sourceNameOverride"></param>
         /// <returns>IFluentLogBuilder.</returns>
-        IFluentLogBuilder Trace([CallerFilePath] string callerFilePath = null);
+        IFluentLogBuilder Trace(int verbosity = 0, string sourceNameOverride = null);
 
         /// <summary>
         ///     Creates a log builder for a log entry with Debug severity.
         /// </summary>
         /// <param name="callerFilePath">The caller file path.</param>
         /// <returns>IFluentLogBuilder.</returns>
-        IFluentLogBuilder Debug([CallerFilePath] string callerFilePath = null);
+        IFluentLogBuilder Debug(int verbosity = 0, string sourceNameOverride = null);
 
         /// <summary>
         ///     Creates a log builder for a log entry with Information severity.
         /// </summary>
         /// <param name="callerFilePath">The caller file path.</param>
         /// <returns>IFluentLogBuilder.</returns>
-        IFluentLogBuilder Info([CallerFilePath] string callerFilePath = null);
+        IFluentLogBuilder Info(int verbosity = 0, string sourceNameOverride = null);
 
         /// <summary>
         ///     Creates a log builder for a log entry with Warning severity.
         /// </summary>
         /// <param name="callerFilePath">The caller file path.</param>
         /// <returns>IFluentLogBuilder.</returns>
-        IFluentLogBuilder Warn([CallerFilePath] string callerFilePath = null);
+        IFluentLogBuilder Warn(int verbosity = 0, string sourceNameOverride = null);
 
         /// <summary>
         ///     Creates a log builder for a log entry with Error severity.
         /// </summary>
         /// <param name="callerFilePath">The caller file path.</param>
         /// <returns>IFluentLogBuilder.</returns>
-        IFluentLogBuilder Error([CallerFilePath] string callerFilePath = null);
+        IFluentLogBuilder Error(int verbosity = 0, string sourceNameOverride = null);
 
         /// <summary>
         ///     Creates a log builder for a log entry with Fatal severity.
@@ -48,7 +58,7 @@ namespace TA.Utils.Core.Diagnostics
         /// </summary>
         /// <param name="callerFilePath">The caller file path.</param>
         /// <returns>IFluentLogBuilder.</returns>
-        IFluentLogBuilder Fatal([CallerFilePath] string callerFilePath = null);
+        IFluentLogBuilder Fatal(int verbosity = 0, string sourceNameOverride = null);
 
         /// <summary>
         ///     Instructs the logging service to shut down.
@@ -65,12 +75,12 @@ namespace TA.Utils.Core.Diagnostics
         ILog WithAmbientProperty(string name, object value);
 
         /// <summary>
-        /// Sets the name of the logger, which can be used by a logging back-end for filtering and routing
-        /// of log entries. If unset, then the value is implementation dependent and may default to the name
-        /// of the class or source file where the ILog instance is created or injected, or some other value.
+        ///     Sets the name of the logger, which can be used by a logging back-end for filtering and routing
+        ///     of log entries. If unset, then the value is implementation dependent and may default to the name
+        ///     of the class or source file where the ILog instance is created or injected, or some other value.
         /// </summary>
         /// <param name="logSourceName"></param>
         /// <returns></returns>
         ILog WithName(string logSourceName);
-        }
     }
+}

--- a/TA.Utils.Core/TA.Utils.Core.csproj
+++ b/TA.Utils.Core/TA.Utils.Core.csproj
@@ -26,8 +26,17 @@
   </PropertyGroup>
 
   <PropertyGroup>
-    <DocumentationFile>TA.Utils.Core.xml</DocumentationFile>
+    <DocumentationFile></DocumentationFile>
     <PackageIcon>TA-Utilities-256x256.png</PackageIcon>
+    <GenerateDocumentationFile>True</GenerateDocumentationFile>
+  </PropertyGroup>
+
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">
+    <DebugType>embedded</DebugType>
+  </PropertyGroup>
+
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|AnyCPU'">
+    <DebugType>embedded</DebugType>
   </PropertyGroup>
 
   <ItemGroup>

--- a/TA.Utils.Logging.NLog.SampleConsoleApp/NLog.config
+++ b/TA.Utils.Logging.NLog.SampleConsoleApp/NLog.config
@@ -22,7 +22,7 @@
 
   <targets async="true" >
     <target xsi:type="ColoredConsole" name="console"
-            layout="${time} | ${pad:padding=-5:inner=${uppercase:${level}}} | ${pad:padding=-31:inner=${logger}} | ${message}" >
+            layout="${time} | ${pad:padding=-5:inner=${uppercase:${level}}} ${event-properties:Item=verbosity} | ${pad:padding=-31:inner=${logger}} | ${message}" >
       <highlight-row condition="level == LogLevel.Debug" foregroundColor="DarkGreen" />
       <highlight-row condition="level == LogLevel.Info" foregroundColor="White" />
       <highlight-row condition="level == LogLevel.Warn" foregroundColor="Yellow" />
@@ -37,7 +37,7 @@
     -->
     <target name="seq" xsi:type="BufferingWrapper" bufferSize="1000"
             flushTimeout="500" slidingTimeout="false">
-      <target xsi:type="Seq" name="seq" serverUrl="http://seq.tigra-astronomy.com:5341" apiKey="6nKZVA6jR2jkRh7Waqvw">
+      <target xsi:type="Seq" name="seq" serverUrl="http://192.168.0.70:5341" apiKey="GCopuScoeDgbAFPGAAVz">
         <!-- Augment the log data with some extra properties -->
         <property name="ProcessId" value="${processid}" />
         <property name="ProcessName" value="${processname}" />

--- a/TA.Utils.Logging.NLog.SampleConsoleApp/Program.cs
+++ b/TA.Utils.Logging.NLog.SampleConsoleApp/Program.cs
@@ -15,78 +15,77 @@ using System.Threading.Tasks;
 using TA.Utils.Core;
 using TA.Utils.Core.Diagnostics;
 
-namespace TA.Utils.Logging.NLog.SampleConsoleApp
+namespace TA.Utils.Logging.NLog.SampleConsoleApp;
+
+/// <summary>
+///     This program demonstrates how to use the <see cref="ILog" /> logging service
+///     and examples of structured or semantic logging. Traditional logging usually
+///     involves writing out a simple string, but with semantic logging we can
+///     include all sorts of data in every log event. For example, when logging an
+///     exception the full exception data including the stack trace is saved to the log.
+///     In this example we are using the NLog back-end and sending the log entries
+///     to the console (with color highlighting) as well as to a cloud log collector.
+///     NLog is configured in the NLog.config file.
+/// </summary>
+internal class Program
 {
-    /// <summary>
-    ///     This program demonstrates how to use the <see cref="ILog" /> logging service
-    ///     and examples of structured or semantic logging. Traditional logging usually
-    ///     involves writing out a simple string, but with semantic logging we can
-    ///     include all sorts of data in every log event. For example, when logging an
-    ///     exception the full exception data including the stack trace is saved to the log.
-    ///     In this example we are using the NLog back-end and sending the log entries
-    ///     to the console (with color highlighting) as well as to a cloud log collector.
-    ///     NLog is configured in the NLog.config file.
-    /// </summary>
-    internal class Program
+    private static readonly List<int> SuperstitiousNumbers = new() { 13, 7, 666, 3, 8, 88, 888 };
+
+    private static async Task Main(string[] args)
     {
-        private static readonly List<int> SuperstitiousNumbers = new List<int> { 13, 7, 666, 3, 8, 88, 888 };
+        // Create a logging service with an ambient property "CorrelationId".
+        // This ID will then appear in all log entries, and can be used to find all entries
+        // related to a particular run of the program.
+        // If this doesn't seem useful, try running two simultaneous instances of the program
+        // and then try to sort out which log entry came from which instance.
+        // The correlation ID makes this trivial.
+        var options = LogServiceOptions.DefaultOptions.UseVerbosity();
+        var log = new LoggingService(options).WithAmbientProperty("CorrelationId", Guid.NewGuid());
+        log.Info()
+            .Message("Application starting - version {Version}", GitVersion.GitInformationalVersion)
+            .Property("SemVer", GitVersion.GitFullSemVer)
+            .Property("GitCommit", GitVersion.GitCommitSha)
+            .Property("CommitDate", GitVersion.GitCommitDate)
+            .Write();
+        var seed = DateTime.Now.Millisecond;
+        var gameOfChance = new Random(seed);
+        log.Debug().Message("Random seed {seed}", seed).Write();
 
-        private static async Task Main(string[] args)
+        for (var i = 0; i < 1000; i++)
         {
-            // Create a logging service with an ambient property "CorrelationId".
-            // This ID will then appear in all log entries, and an be used to find all entries
-            // related to a particular run of the program.
-            // If this doesn't seem useful, try running two simultaneous instances of the program
-            // and then try to sort out which log entry came from which instance.
-            // The correlation ID makes this trivial.
-            var log = new LoggingService().WithAmbientProperty("CorrelationId", Guid.NewGuid());
-            log.Info()
-                .Message("Application starting - version {Version}", GitVersion.GitInformationalVersion)
-                .Property("SemVer", GitVersion.GitFullSemVer)
-                .Property("GitCommit", GitVersion.GitCommitSha)
-                .Property("CommitDate", GitVersion.GitCommitDate)
-                .Write();
-            var seed = DateTime.Now.Millisecond;
-            var gameOfChance = new Random(seed);
-            log.Debug().Message("Random seed {seed}", seed).Write();
-
-            for (var i = 0; i < 1000; i++)
+            try
             {
-                try
-                {
-                    log.Debug().Message("Starting iteration {iteration}", i).Write();
+                log.Debug(1).Message("Starting iteration {iteration}", i).Write();
 
-                    /*
-                     * The program doesn't like numbers associated with superstition,
-                     * and will flag them up as warnings.
-                     */
-                    if (SuperstitiousNumbers.Contains(i))
-                        throw new SuperstitiousNumberException($"Skipping {i} because it is a superstitious number");
+                /*
+                 * The program doesn't like numbers associated with superstition,
+                 * and will flag them up as warnings.
+                 */
+                if (SuperstitiousNumbers.Contains(i))
+                    throw new SuperstitiousNumberException($"Skipping {i} because it is a superstitious number");
 
-                    // There's a small chance of a random "failure"
-                    if (gameOfChance.Next(100) < 3)
-                        throw new ApplicationException("Random failure");
-                }
-                catch (SuperstitiousNumberException ex)
-                {
-                    log.Warn()
-                        .Message("Superstitious looking number: {number}", i)
-                        .Exception(ex)
-                        .Property("SuperstitiousNumbers", SuperstitiousNumbers)
-                        .Write();
-                }
-                catch (ApplicationException ae)
-                {
-                    log.Error().Exception(ae).Message("Failed iteration {iteration}", i).Write();
-                }
-
-                await Task.Delay(TimeSpan.FromMilliseconds(1000));
-                log.Debug().Message("Finished iteration {iteration}", i).Write();
+                // There's a small chance of a random "failure"
+                if (gameOfChance.Next(100) < 3)
+                    throw new ApplicationException("Random failure");
+            }
+            catch (SuperstitiousNumberException ex)
+            {
+                log.Warn()
+                    .Message("Superstitious looking number: {number}", i)
+                    .Exception(ex)
+                    .Property("SuperstitiousNumbers", SuperstitiousNumbers)
+                    .Write();
+            }
+            catch (ApplicationException ae)
+            {
+                log.Error().Exception(ae).Message("Failed iteration {iteration}", i).Write();
             }
 
-            log.Trace(5).Message("Testing trace verbosity").Write();
-            log.Info().Message("Program terminated").Write();
-            log.Shutdown();
+            await Task.Delay(TimeSpan.FromMilliseconds(1000));
+            log.Debug(1).Message("Finished iteration {iteration}", i).Write();
         }
+
+        log.Info().Message("Program terminated").Write();
+        log.Shutdown();
     }
 }

--- a/TA.Utils.Logging.NLog.SampleConsoleApp/Program.cs
+++ b/TA.Utils.Logging.NLog.SampleConsoleApp/Program.cs
@@ -1,6 +1,13 @@
 ﻿// This file is part of the TA.Utils project
-// Copyright © 2016-2020 Tigra Astronomy, all rights reserved.
-// File: Program.cs  Last modified: 2020-07-16@19:24 by Tim Long
+// Copyright © 2015-2023 Timtek Systems Limited, all rights reserved.
+// 
+// Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated
+// documentation files (the "Software"), to deal in the Software without restriction, including without limitation
+// the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to
+// permit persons to whom the Software is furnished to do so. The Software comes with no warranty of any kind.
+// You make use of the Software entirely at your own risk and assume all liability arising from your use thereof.
+// 
+// File: Program.cs  Last modified: 2023-09-01@10:58 by Tim Long
 
 using System;
 using System.Collections.Generic;
@@ -9,38 +16,44 @@ using TA.Utils.Core;
 using TA.Utils.Core.Diagnostics;
 
 namespace TA.Utils.Logging.NLog.SampleConsoleApp
-    {
+{
     /// <summary>
-    /// This program demonstrates how to use the <see cref="ILog"/> logging service
-    /// and examples of structured or semantic logging. Traditional logging usually
-    /// involves writing out a simple string, but with semantic logging we can
-    /// include all sorts of data in every log event. For example, when logging an
-    /// exception the full exception data including the stack trace is saved to the log.
-    /// In this example we are using the NLog back-end and sending the log entries
-    /// to the console (with color highlighting) as well as to a cloud log collector.
-    /// NLog is configured in the NLog.config file.
+    ///     This program demonstrates how to use the <see cref="ILog" /> logging service
+    ///     and examples of structured or semantic logging. Traditional logging usually
+    ///     involves writing out a simple string, but with semantic logging we can
+    ///     include all sorts of data in every log event. For example, when logging an
+    ///     exception the full exception data including the stack trace is saved to the log.
+    ///     In this example we are using the NLog back-end and sending the log entries
+    ///     to the console (with color highlighting) as well as to a cloud log collector.
+    ///     NLog is configured in the NLog.config file.
     /// </summary>
-    class Program
-        {
-        static readonly List<int> SuperstitiousNumbers = new List<int> {13, 7, 666, 3, 8, 88, 888};
+    internal class Program
+    {
+        private static readonly List<int> SuperstitiousNumbers = new List<int> { 13, 7, 666, 3, 8, 88, 888 };
 
-        static async Task Main(string[] args)
-            {
-            var log = new LoggingService();
+        private static async Task Main(string[] args)
+        {
+            // Create a logging service with an ambient property "CorrelationId".
+            // This ID will then appear in all log entries, and an be used to find all entries
+            // related to a particular run of the program.
+            // If this doesn't seem useful, try running two simultaneous instances of the program
+            // and then try to sort out which log entry came from which instance.
+            // The correlation ID makes this trivial.
+            var log = new LoggingService().WithAmbientProperty("CorrelationId", Guid.NewGuid());
             log.Info()
-                .Message("Application stating - version {Version}", GitVersion.GitInformationalVersion)
+                .Message("Application starting - version {Version}", GitVersion.GitInformationalVersion)
                 .Property("SemVer", GitVersion.GitFullSemVer)
                 .Property("GitCommit", GitVersion.GitCommitSha)
                 .Property("CommitDate", GitVersion.GitCommitDate)
                 .Write();
             var seed = DateTime.Now.Millisecond;
             var gameOfChance = new Random(seed);
-            log.Debug().Property("seed",seed).Write();
+            log.Debug().Message("Random seed {seed}", seed).Write();
 
-            for (int i = 0; i < 1000; i++)
-                {
+            for (var i = 0; i < 1000; i++)
+            {
                 try
-                    {
+                {
                     log.Debug().Message("Starting iteration {iteration}", i).Write();
 
                     /*
@@ -48,31 +61,32 @@ namespace TA.Utils.Logging.NLog.SampleConsoleApp
                      * and will flag them up as warnings.
                      */
                     if (SuperstitiousNumbers.Contains(i))
-                        {
                         throw new SuperstitiousNumberException($"Skipping {i} because it is a superstitious number");
-                        }
 
                     // There's a small chance of a random "failure"
                     if (gameOfChance.Next(100) < 3)
                         throw new ApplicationException("Random failure");
-                    }
+                }
                 catch (SuperstitiousNumberException ex)
-                    {
+                {
                     log.Warn()
                         .Message("Superstitious looking number: {number}", i)
                         .Exception(ex)
                         .Property("SuperstitiousNumbers", SuperstitiousNumbers)
                         .Write();
-                    }
+                }
                 catch (ApplicationException ae)
-                    {
+                {
                     log.Error().Exception(ae).Message("Failed iteration {iteration}", i).Write();
-                    }
+                }
+
                 await Task.Delay(TimeSpan.FromMilliseconds(1000));
                 log.Debug().Message("Finished iteration {iteration}", i).Write();
-                }
+            }
+
+            log.Trace(5).Message("Testing trace verbosity").Write();
             log.Info().Message("Program terminated").Write();
             log.Shutdown();
-            }
         }
     }
+}

--- a/TA.Utils.Logging.NLog.SampleConsoleApp/TA.Utils.Logging.NLog.SampleConsoleApp.csproj
+++ b/TA.Utils.Logging.NLog.SampleConsoleApp/TA.Utils.Logging.NLog.SampleConsoleApp.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/TA.Utils.Logging.NLog.SampleConsoleApp/TA.Utils.Logging.NLog.SampleConsoleApp.csproj
+++ b/TA.Utils.Logging.NLog.SampleConsoleApp/TA.Utils.Logging.NLog.SampleConsoleApp.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/TA.Utils.Logging.Nlog/LogBuilder.cs
+++ b/TA.Utils.Logging.Nlog/LogBuilder.cs
@@ -13,11 +13,23 @@ using TA.Utils.Core.Diagnostics;
 
 namespace TA.Utils.Logging.NLog
 {
+    /// <summary>
+    /// Provides a fluent interface for constructing log entries based on the NLog back-end logging service.
+    /// The fluent API is loosely based on the API used by NLog.
+    /// </summary>
     internal sealed class LogBuilder : IFluentLogBuilder
     {
         private readonly LogEventInfo logEvent;
         private readonly ILogger logger;
 
+        /// <summary>
+        /// Construct a new log event builder at a given logging verbosity level, ensuring that any ambient properties are used.
+        /// Instances of the builder object are typically created by the logging service, but can also be constructed on demand.
+        /// </summary>
+        /// <param name="logger">An instance of a logging service that will eventually accept the built log entry.</param>
+        /// <param name="level">The verbosity level of the log entry being built.</param>
+        /// <param name="ambientProperties">Any ambient properties that should be included in the log entry.</param>
+        /// <exception cref="ArgumentNullException">Thrown if there is no logging service or verbosity level specified.</exception>
         public LogBuilder(ILogger logger, LogLevel level, IDictionary<string, object> ambientProperties = null)
         {
             if (logger == null)

--- a/TA.Utils.Logging.Nlog/LogServiceOptions.cs
+++ b/TA.Utils.Logging.Nlog/LogServiceOptions.cs
@@ -1,0 +1,50 @@
+﻿// This file is part of the TA.Utils project
+// Copyright © 2015-2023 Timtek Systems Limited, all rights reserved.
+// 
+// Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated
+// documentation files (the "Software"), to deal in the Software without restriction, including without limitation
+// the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to
+// permit persons to whom the Software is furnished to do so. The Software comes with no warranty of any kind.
+// You make use of the Software entirely at your own risk and assume all liability arising from your use thereof.
+// 
+// File: LogServiceOptions.cs  Last modified: 2023-09-01@20:23 by Tim Long
+
+namespace TA.Utils.Logging.NLog
+{
+    /// <summary>
+    ///     Options that affect the operation of the <see cref="LoggingService" />.
+    /// </summary>
+    public class LogServiceOptions
+    {
+        private const string VerbosityDefaultPropertyName = "verbosity";
+        internal bool VerbosityEnabled;
+        internal string VerbosityPropertyName = VerbosityDefaultPropertyName;
+
+        private LogServiceOptions() { } // prevent use of the  except within the class itself.
+
+        /// <summary>
+        ///     Returns an instance loaded with default options, which can then be modified.
+        ///     This is the primary creation mechanism for options.
+        /// </summary>
+        public static LogServiceOptions DefaultOptions => new LogServiceOptions();
+
+        /// <summary>
+        ///     Enables the use of "verbosity".
+        ///     Causes a property to be added to each log entry containing a verbosity level, which defaults to 0.
+        ///     The verbosity of each entry can be set when creating a log entry, by passing it as a parameter to the severity
+        ///     builder method.
+        ///     <example>
+        ///         To create a log entry with severity Info and verbosity 2, proceed as follows:
+        ///         <c>Log.Info(2).Message("sets verbosity 2").Write();</c>
+        ///     </example>
+        /// </summary>
+        /// <param name="verbosityPropertyName">The name of the verbosity property.. Optional; defaults to "verbosity".</param>
+        /// <returns>The <see cref="LogServiceOptions" /> instance.</returns>
+        public LogServiceOptions UseVerbosity(string verbosityPropertyName = VerbosityDefaultPropertyName)
+        {
+            VerbosityEnabled = true;
+            VerbosityPropertyName = verbosityPropertyName;
+            return this;
+        }
+    }
+}

--- a/TA.Utils.Logging.Nlog/LoggingService.cs
+++ b/TA.Utils.Logging.Nlog/LoggingService.cs
@@ -1,95 +1,123 @@
 ﻿// This file is part of the TA.Utils project
-// Copyright © 2016-2023 Timtek Systems Limited, all rights reserved.
-// File: LoggingService.cs  Last modified: 2023-08-13@23:30 by Tim Long
+// Copyright © 2015-2023 Timtek Systems Limited, all rights reserved.
+// 
+// Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated
+// documentation files (the "Software"), to deal in the Software without restriction, including without limitation
+// the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to
+// permit persons to whom the Software is furnished to do so. The Software comes with no warranty of any kind.
+// You make use of the Software entirely at your own risk and assume all liability arising from your use thereof.
+// 
+// File: LoggingService.cs  Last modified: 2023-09-01@11:46 by Tim Long
 
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.IO;
-using System.Runtime.CompilerServices;
 using NLog;
 using TA.Utils.Core.Diagnostics;
 
 namespace TA.Utils.Logging.NLog
-    {
+{
     /// <summary>
     ///     A logging service that uses NLog as the back-end logger. Implements the
     ///     <see cref="TA.Utils.Core.Diagnostics.ILog" />
     /// </summary>
     /// <seealso cref="TA.Utils.Core.Diagnostics.ILog" />
     public sealed class LoggingService : ILog
-        {
+    {
         private static readonly ILogger DefaultLogger = LogManager.GetCurrentClassLogger();
         private readonly IDictionary<string, object> ambientProperties = new Dictionary<string, object>();
-        private string sourceName = string.Empty;
+        private string sourceName;
+
+        /// <summary>
+        ///     Static constructor ensures that the logging back-end is loaded and configured,
+        ///     and will shut down cleanly on application domain unload.
+        /// </summary>
+        static LoggingService()
+        {
+            LogManager.AutoShutdown = true;
+        }
 
         /// <summary>Static initializer can be used to perform 1-time NLog configurations.</summary>
-        static LoggingService()
-            {
-            LogManager.AutoShutdown = true;
-            }
+        public LoggingService()
+        {
+            // Reflect on the calling type and use its type name as the log source name.
+            // This can be overridden later using the .WithName() method.
+            var callerStackFrame = new StackFrame(1);
+            var callerMethod = callerStackFrame.GetMethod();
+            var callerType = callerMethod.DeclaringType;
+            var callerTypeName = callerType.Name;
+            sourceName = callerTypeName;
+        }
 
         /// <inheritdoc />
-        public IFluentLogBuilder Trace([CallerFilePath] string callerFilePath = null)
-            {
-            return CreateLogBuilder(LogLevel.Trace, callerFilePath);
-            }
+        public IFluentLogBuilder Trace(int verbosity = 0, string sourceNameOverride = null)
+        {
+            return CreateLogBuilder(LogLevel.Trace, sourceNameOverride ?? sourceName)
+                .Property(nameof(verbosity), verbosity);
+        }
 
         /// <inheritdoc />
-        public IFluentLogBuilder Debug([CallerFilePath] string callerFilePath = null)
-            {
-            return CreateLogBuilder(LogLevel.Debug, callerFilePath);
-            }
+        public IFluentLogBuilder Debug(int verbosity = 0, string sourceNameOverride = null)
+        {
+            return CreateLogBuilder(LogLevel.Debug, sourceNameOverride ?? sourceName)
+                .Property(nameof(verbosity), verbosity);
+        }
 
         /// <inheritdoc />
-        public IFluentLogBuilder Info([CallerFilePath] string callerFilePath = null)
-            {
-            return CreateLogBuilder(LogLevel.Info, callerFilePath);
-            }
+        public IFluentLogBuilder Info(int verbosity = 0, string sourceNameOverride = null)
+        {
+            return CreateLogBuilder(LogLevel.Info, sourceNameOverride ?? sourceName)
+                .Property(nameof(verbosity), verbosity);
+        }
 
         /// <inheritdoc />
-        public IFluentLogBuilder Warn([CallerFilePath] string callerFilePath = null)
-            {
-            return CreateLogBuilder(LogLevel.Warn, callerFilePath);
-            }
+        public IFluentLogBuilder Warn(int verbosity = 0, string sourceNameOverride = null)
+        {
+            return CreateLogBuilder(LogLevel.Warn, sourceNameOverride ?? sourceName)
+                .Property(nameof(verbosity), verbosity);
+        }
 
         /// <inheritdoc />
-        public IFluentLogBuilder Error([CallerFilePath] string callerFilePath = null)
-            {
-            return CreateLogBuilder(LogLevel.Error, callerFilePath);
-            }
+        public IFluentLogBuilder Error(int verbosity = 0, string sourceNameOverride = null)
+        {
+            return CreateLogBuilder(LogLevel.Error, sourceNameOverride ?? sourceName)
+                .Property(nameof(verbosity), verbosity);
+        }
 
         /// <inheritdoc />
-        public IFluentLogBuilder Fatal([CallerFilePath] string callerFilePath = null)
-            {
-            return CreateLogBuilder(LogLevel.Fatal, callerFilePath);
-            }
+        public IFluentLogBuilder Fatal(int verbosity = 0, string sourceNameOverride = null)
+        {
+            return CreateLogBuilder(LogLevel.Fatal, sourceNameOverride ?? sourceName)
+                .Property(nameof(verbosity), verbosity);
+        }
 
         /// <inheritdoc />
         public void Shutdown()
-            {
+        {
             LogManager.Shutdown();
-            }
+        }
 
         /// <inheritdoc />
         public ILog WithAmbientProperty(string name, object value)
-            {
+        {
             ambientProperties[name] = value;
             return this;
-            }
+        }
 
         /// <inheritdoc />
         public ILog WithName(string logSourceName)
-            {
+        {
             sourceName = logSourceName;
             return this;
-            }
+        }
 
         private IFluentLogBuilder CreateLogBuilder(LogLevel logLevel, string callerFilePath)
-            {
+        {
             var name = GetLoggerName(callerFilePath);
             var logger = string.IsNullOrWhiteSpace(name) ? DefaultLogger : LogManager.GetLogger(name);
             var builder = new LogBuilder(logger, logLevel, ambientProperties);
             return builder;
-            }
+        }
 
         /// <summary>
         ///     Gets the name for this logger instance.
@@ -100,13 +128,13 @@ namespace TA.Utils.Logging.NLog
         /// <param name="callerFilePath">The name of the caller's source file, if known.</param>
         /// <returns>A string containing the suggested logger name.</returns>
         private string GetLoggerName(string callerFilePath)
-            {
+        {
             if (!string.IsNullOrWhiteSpace(sourceName))
                 return sourceName;
             var name = !string.IsNullOrWhiteSpace(callerFilePath)
                 ? Path.GetFileNameWithoutExtension(callerFilePath)
                 : string.Empty;
             return name;
-            }
         }
     }
+}

--- a/TA.Utils.Logging.Nlog/TA.Utils.Logging.Nlog.csproj
+++ b/TA.Utils.Logging.Nlog/TA.Utils.Logging.Nlog.csproj
@@ -24,8 +24,17 @@
   </PropertyGroup>
 
   <PropertyGroup>
-    <DocumentationFile>TA.Utils.Logging.Nlog.xml</DocumentationFile>
+    <DocumentationFile></DocumentationFile>
     <PackageIcon>TA-Utilities-256x256.png</PackageIcon>
+    <GenerateDocumentationFile>True</GenerateDocumentationFile>
+  </PropertyGroup>
+
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">
+    <DebugType>embedded</DebugType>
+  </PropertyGroup>
+
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|AnyCPU'">
+    <DebugType>embedded</DebugType>
   </PropertyGroup>
 
   <ItemGroup>

--- a/TA.Utils.Specifications/NLogLogServiceSpecs.cs
+++ b/TA.Utils.Specifications/NLogLogServiceSpecs.cs
@@ -25,22 +25,22 @@ namespace TA.Utils.Specifications
     internal class when_building_a_default_logger : with_caller_info_context
         {
         Establish context = () => builder = (LogBuilder)new LoggingService().Info();
-        It should_have_the_file_name = () => builder.Build().LoggerName.ShouldEqual(CallerFileNameWithoutExtenstion());
+        It should_have_the_class_name_as_source = () => builder.Build().LoggerName.ShouldEqual("<>c");
         static LogBuilder builder;
         }
 
     internal class when_creating_a_named_logger : with_caller_info_context
         {
-        // ReSharper disable once ExplicitCallerInfoArgument
-        Establish context = () => builder = (LogBuilder)new LoggingService().Info("Roger");
-        It should_change_the_name = () => builder.Build().LoggerName.ShouldEqual("Roger");
+            // ReSharper disable once ExplicitCallerInfoArgument
+            Establish context = () => builder = (LogBuilder)new LoggingService().WithName("Roger").Info();
+            It should_change_the_name = () => builder.Build().LoggerName.ShouldEqual("Roger");
         static LogBuilder builder;
         }
 
-    internal class when_creating_and_building_a_named_logger : with_caller_info_context
-        {
+    class when_overriding_the_log_source_name : with_caller_info_context
+    {
         // ReSharper disable once ExplicitCallerInfoArgument
-        Establish context = () => builder = (LogBuilder)new LoggingService().Info("Roger");
+        Establish context = () => builder = (LogBuilder)new LoggingService().Info(sourceNameOverride: "Roger");
         Because of = () => builder.LoggerName("Jim");
         It should_change_the_name = () => builder.Build().LoggerName.ShouldEqual("Jim");
         static LogBuilder builder;

--- a/TA.Utils.Specifications/NLogLogServiceSpecs.cs
+++ b/TA.Utils.Specifications/NLogLogServiceSpecs.cs
@@ -2,66 +2,96 @@
 // Copyright © 2016-2020 Tigra Astronomy, all rights reserved.
 // File: NLogLogServiceSpecs.cs  Last modified: 2020-07-19@20:23 by Tim Long
 
+using System;
 using System.IO;
 using System.Runtime.CompilerServices;
 using Machine.Specifications;
 using TA.Utils.Core.Diagnostics;
 using TA.Utils.Logging.NLog;
 
-namespace TA.Utils.Specifications
+// ReSharper disable UnusedMember.Local
+
+namespace TA.Utils.Specifications;
+
+#region Context base classes
+
+class with_caller_info_context
+{
+    protected static string CallerFileNameWithoutExtenstion([CallerFilePath] string callerFilePath = null)
     {
-    internal class with_caller_info_context
-        {
-        protected static string CallerFileNameWithoutExtenstion([CallerFilePath] string callerFilePath = null)
-            {
-            const string unknown = "(unknown)";
-            if (string.IsNullOrWhiteSpace(callerFilePath))
-                return unknown;
-            var fileName = Path.GetFileNameWithoutExtension(callerFilePath);
-            return string.IsNullOrWhiteSpace(fileName) ? unknown : fileName;
-            }
-        }
-
-    internal class when_building_a_default_logger : with_caller_info_context
-        {
-        Establish context = () => builder = (LogBuilder)new LoggingService().Info();
-        It should_have_the_class_name_as_source = () => builder.Build().LoggerName.ShouldEqual("<>c");
-        static LogBuilder builder;
-        }
-
-    internal class when_creating_a_named_logger : with_caller_info_context
-        {
-            // ReSharper disable once ExplicitCallerInfoArgument
-            Establish context = () => builder = (LogBuilder)new LoggingService().WithName("Roger").Info();
-            It should_change_the_name = () => builder.Build().LoggerName.ShouldEqual("Roger");
-        static LogBuilder builder;
-        }
-
-    class when_overriding_the_log_source_name : with_caller_info_context
-    {
-        // ReSharper disable once ExplicitCallerInfoArgument
-        Establish context = () => builder = (LogBuilder)new LoggingService().Info(sourceNameOverride: "Roger");
-        Because of = () => builder.LoggerName("Jim");
-        It should_change_the_name = () => builder.Build().LoggerName.ShouldEqual("Jim");
-        static LogBuilder builder;
-        }
-
-    internal class when_building_a_named_logger : with_caller_info_context
-        {
-        Establish context = () => builder = (LogBuilder)new LoggingService().Info();
-        Because of = () => builder.LoggerName("Jim");
-        It should_change_the_name = () => builder.Build().LoggerName.ShouldEqual("Jim");
-        static LogBuilder builder;
-        }
-
-    [Subject(typeof(LoggingService), "ambient properties")]
-    internal class when_creating_a_logger_with_ambient_properties
-        {
-        Establish context = () => log = new LoggingService().WithAmbientProperty(PropertyName, true);
-        Because of = () => builder = log.Debug() as LogBuilder;
-        It should_add_the_ambient_properties = () => builder.Build().Properties.ContainsKey(PropertyName).ShouldBeTrue();
-        private static LogBuilder builder;
-        private static ILog log;
-        private const string PropertyName = "TestProperty";
-        }
+        const string unknown = "(unknown)";
+        if (string.IsNullOrWhiteSpace(callerFilePath))
+            return unknown;
+        var fileName = Path.GetFileNameWithoutExtension(callerFilePath);
+        return string.IsNullOrWhiteSpace(fileName) ? unknown : fileName;
     }
+}
+
+#endregion
+
+class when_building_a_default_logger : with_caller_info_context
+{
+    Establish context = () => builder = (LogBuilder)new LoggingService().Info();
+    It should_have_the_class_name_as_source = () => builder.Build().LoggerName.ShouldEqual(nameof(when_building_a_default_logger));
+    static LogBuilder builder;
+}
+
+class when_creating_a_named_logger : with_caller_info_context
+{
+    Establish context = () => builder = (LogBuilder)new LoggingService().WithName("Roger").Info();
+    It should_override_the_default_name = () => builder.Build().LoggerName.ShouldEqual("Roger");
+    static LogBuilder builder;
+}
+
+class when_overriding_the_log_source_name_for_one_log_event : with_caller_info_context
+{
+    Establish context = () => builder = (LogBuilder)new LoggingService().Info(sourceNameOverride: "Roger");
+    Because of = () => builder.LoggerName("Jim");
+    It should_override_the_logger_name = () => builder.Build().LoggerName.ShouldEqual("Jim");
+    static LogBuilder builder;
+}
+
+class when_building_a_named_logger : with_caller_info_context
+{
+    Establish context = () => builder = (LogBuilder)new LoggingService().Info();
+    Because of = () => builder.LoggerName("Jim");
+    It should_change_the_name = () => builder.Build().LoggerName.ShouldEqual("Jim");
+    static LogBuilder builder;
+}
+
+[Subject(typeof(LoggingService), "ambient properties")]
+class when_creating_a_logger_with_ambient_properties
+{
+    Establish context = () => log = new LoggingService().WithAmbientProperty(PropertyName, true);
+    Because of = () => builder = log.Debug() as LogBuilder;
+    It should_add_the_ambient_properties = () => builder.Build().Properties.ContainsKey(PropertyName).ShouldBeTrue();
+    static LogBuilder builder;
+    static ILog log;
+    const string PropertyName = "TestProperty";
+}
+
+class when_adding_a_property_with_a_conflicting_name
+{
+    Establish context = () => logService = new LoggingService();
+    Because of = () => builder = logService.Info().Property("conflictedName", 1).Property("conflictedName", 2) as LogBuilder;
+    It should_keep_the_original_property_name = () => builder.PeekLogEvent.Properties.ContainsKey("conflictedName").ShouldBeTrue();
+    It should_keep_the_original_property_value = () => builder.PeekLogEvent.Properties["conflictedName"].ShouldEqual(1);
+    It should_deconflict_the_new_property_name = () => builder.PeekLogEvent.Properties.ContainsKey("conflictedName1").ShouldBeTrue();
+    It should_add_the_new_value = () => builder.PeekLogEvent.Properties["conflictedName1"].ShouldEqual(2);
+    static LogBuilder builder;
+    static LoggingService logService;
+}
+
+class when_adding_many_conflicting_properties
+{
+    Because of = () => exception = Catch.Exception(AddLotsOfConflictingProperrties);
+
+    It should_eventually_throw = () => exception.ShouldBeOfExactType<ArgumentException>();
+    static Exception exception;
+
+    static void AddLotsOfConflictingProperrties()
+    {
+        var builder = new LoggingService().Info();
+        for (var i = 0; i < 1000; ++i) builder.Property("conflictedName", 99);
+    }
+}

--- a/TA.Utils.Specifications/TA.Utils.Specifications.csproj
+++ b/TA.Utils.Specifications/TA.Utils.Specifications.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/TA.Utils.Specifications/TA.Utils.Specifications.csproj
+++ b/TA.Utils.Specifications/TA.Utils.Specifications.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/TA.Utils.sln.DotSettings
+++ b/TA.Utils.sln.DotSettings
@@ -1,7 +1,15 @@
 ﻿<wpf:ResourceDictionary xml:space="preserve" xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml" xmlns:s="clr-namespace:System;assembly=mscorlib" xmlns:ss="urn:shemas-jetbrains-com:settings-storage-xaml" xmlns:wpf="http://schemas.microsoft.com/winfx/2006/xaml/presentation">
 	<s:String x:Key="/Default/CodeStyle/FileHeader/FileHeaderText/@EntryValue">This file is part of the $SOLUTION$ project&#xD;
-Copyright © 2016-$CURRENT_YEAR$ Timtek Systems Limited, all rights reserved.&#xD;
-File: $FILENAME$  Last modified: $CURRENT_YEAR$-$CURRENT_MONTH$-$CURRENT_DAY$@$CURRENT_TIME$ by $USER_NAME$</s:String>
+Copyright © 2015-$CURRENT_YEAR$ Timtek Systems Limited, all rights reserved.&#xD;
+&#xD;
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated&#xD;
+documentation files (the "Software"), to deal in the Software without restriction, including without limitation&#xD;
+the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to&#xD;
+permit persons to whom the Software is furnished to do so. The Software comes with no warranty of any kind.&#xD;
+You make use of the Software entirely at your own risk and assume all liability arising from your use thereof.&#xD;
+&#xD;
+File: $FILENAME$  Last modified: $CURRENT_YEAR$-$CURRENT_MONTH$-$CURRENT_DAY$@$CURRENT_TIME$ by $USER_NAME$&#xD;
+</s:String>
 	<s:String x:Key="/Default/CodeStyle/Naming/CSharpNaming/PredefinedNamingRules/=PrivateStaticFields/@EntryIndexedValue">&lt;Policy Inspect="True" Prefix="" Suffix="" Style="aaBb" /&gt;</s:String>
 	<s:String x:Key="/Default/Environment/InjectedLayers/FileInjectedLayer/=C416A94FC578474BAE38CF2376C5BEA9/AbsolutePath/@EntryValue">C:\Users\Tim\source\repos\TA.Utils\TA.Utils.Specifications\TA.Utils.Specifications.csproj.DotSettings</s:String>
 	<s:String x:Key="/Default/Environment/InjectedLayers/FileInjectedLayer/=C416A94FC578474BAE38CF2376C5BEA9/RelativePath/@EntryValue">..\TA.Utils.Specifications\TA.Utils.Specifications.csproj.DotSettings</s:String>

--- a/TA.Utils.sln.DotSettings
+++ b/TA.Utils.sln.DotSettings
@@ -23,4 +23,8 @@ File: $FILENAME$  Last modified: $CURRENT_YEAR$-$CURRENT_MONTH$-$CURRENT_DAY$@$C
 	<s:Boolean x:Key="/Default/Environment/InjectedLayers/InjectedLayerCustomization/=FileC416A94FC578474BAE38CF2376C5BEA9/IsOn/@EntryValue">False</s:Boolean>
 	
 	<s:Double x:Key="/Default/Environment/InjectedLayers/InjectedLayerCustomization/=FileC416A94FC578474BAE38CF2376C5BEA9/RelativePriority/@EntryValue">1</s:Double>
+	<s:Boolean x:Key="/Default/Environment/SettingsMigration/IsMigratorApplied/=JetBrains_002EReSharper_002EPsi_002ECSharp_002ECodeStyle_002ECSharpKeepExistingMigration/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/Environment/SettingsMigration/IsMigratorApplied/=JetBrains_002EReSharper_002EPsi_002ECSharp_002ECodeStyle_002ECSharpPlaceEmbeddedOnSameLineMigration/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/Environment/SettingsMigration/IsMigratorApplied/=JetBrains_002EReSharper_002EPsi_002ECSharp_002ECodeStyle_002ECSharpUseContinuousIndentInsideBracesMigration/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/Environment/SettingsMigration/IsMigratorApplied/=JetBrains_002EReSharper_002EPsi_002ECSharp_002ECodeStyle_002ESettingsUpgrade_002EMigrateBlankLinesAroundFieldToBlankLinesAroundProperty/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=versioning/@EntryIndexedValue">True</s:Boolean></wpf:ResourceDictionary>

--- a/TA.Utils.sln.DotSettings
+++ b/TA.Utils.sln.DotSettings
@@ -1,4 +1,9 @@
 ﻿<wpf:ResourceDictionary xml:space="preserve" xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml" xmlns:s="clr-namespace:System;assembly=mscorlib" xmlns:ss="urn:shemas-jetbrains-com:settings-storage-xaml" xmlns:wpf="http://schemas.microsoft.com/winfx/2006/xaml/presentation">
+	<s:Boolean x:Key="/Default/CodeStyle/CodeCleanup/CleanupOnSave/@EntryValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/CodeStyle/CodeCleanup/PartCleanupOnRecentlyModifiedFiles/@EntryValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/CodeStyle/CodeCleanup/PartCleanupOnSave/@EntryValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/CodeStyle/CodeFormatting/CSharpFormat/ALLOW_COMMENT_AFTER_LBRACE/@EntryValue">True</s:Boolean>
+	<s:String x:Key="/Default/CodeStyle/CodeFormatting/CSharpFormat/EMPTY_BLOCK_STYLE/@EntryValue">TOGETHER_SAME_LINE</s:String>
 	<s:String x:Key="/Default/CodeStyle/FileHeader/FileHeaderText/@EntryValue">This file is part of the $SOLUTION$ project&#xD;
 Copyright © 2015-$CURRENT_YEAR$ Timtek Systems Limited, all rights reserved.&#xD;
 &#xD;


### PR DESCRIPTION
We found the default 5 severity levels (Error, Warning, Info, Debug, Trace) to be a bit limiting, so we are adding the concept of _verbosity_ for more fine-grained control.

When creating log entries using the fluent builder, the verbosity is specified along with the severity level. Example:

```csharp
Log.Debug(5).Message("logging at Debug severity, verbosity 5").Write();
```

If no verbosity is specified, it defaults to zero (this is backward-compatible).

Verbosity processing must be enabled via the new `LogServiceOptions` class.

```csharp
var options = LogServiceOptions.DefaultOptions.UseVerbocity();
var log = new LoggingService(options);
```
This will cause the logging service to begin adding a property named "verbosity" to each log entry..
If for some reason the property name "verbosity" can't be used, then an alternative name can be specified in the options:

```csharp
var options = LogServiceOptions.DefaultOptions.UseVerbocity("verbosity-safe-property-name");
var log = new LoggingService(options);
```
